### PR TITLE
Changes to allow customize deploy path for self-hosting

### DIFF
--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -16,12 +16,12 @@ class Ruhoh
              xml.title_ Ruhoh::DB.site['title']
              xml.link_ Ruhoh::DB.site['config']['production_url']
              xml.pubDate_ Time.now
-             Ruhoh::DB.posts['chronological'].each do |post_id|
+             Ruhoh::DB.posts['chronological'].first(20).each do |post_id|
                post = Ruhoh::DB.posts['dictionary'][post_id]
                page.change(post_id)
                xml.item {
                  xml.title_ post['title']
-                 xml.link "#{Ruhoh::DB.site['config']['production_url']}#{post['url']}"
+                 xml.link "#{post['url']}".sub(Regexp.new("#{Ruhoh.urls.docroot}"), '')
                  xml.pubDate_ post['date']
                  xml.description_ (post['description'] ? post['description'] : page.render)
                }

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -16,7 +16,7 @@ class Ruhoh
              xml.title_ Ruhoh::DB.site['title']
              xml.link_ Ruhoh::DB.site['config']['production_url']
              xml.pubDate_ Time.now
-             Ruhoh::DB.posts['chronological'].first(20).each do |post_id|
+             Ruhoh::DB.posts['chronological'].first(Ruhoh::DB.site['config']['rss']['latest'].to_i).each do |post_id|
                post = Ruhoh::DB.posts['dictionary'][post_id]
                page.change(post_id)
                xml.item {

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -21,7 +21,7 @@ class Ruhoh
                page.change(post_id)
                xml.item {
                  xml.title_ post['title']
-                 xml.link "#{post['url']}".sub(Regexp.new("#{Ruhoh.urls.docroot}"), '')
+                 xml.link "#{post['url']}"#.sub(Regexp.new("#{Ruhoh.urls.docroot}"), '')
                  xml.pubDate_ post['date']
                  xml.description_ (post['description'] ? post['description'] : page.render)
                }

--- a/lib/ruhoh/config.rb
+++ b/lib/ruhoh/config.rb
@@ -3,6 +3,8 @@ class Ruhoh
   module Config
     Config = Struct.new(
       :env,
+      :production_url,
+      :dev_url,
       :pages_exclude,
       :pages_permalink,
       :pages_layout,
@@ -26,6 +28,10 @@ class Ruhoh
       end
       
       config = Config.new
+      config.production_url = site_config['production_url']
+      config.dev_url = site_config['dev_url'] if config.production_url.nil? 
+      config.production_url = '/' if config.production_url.nil?
+      config.dev_url = '/' if config.dev_url.nil?
       config.theme = theme
       config.env = site_config['env'] || nil
       

--- a/lib/ruhoh/config.rb
+++ b/lib/ruhoh/config.rb
@@ -29,7 +29,7 @@ class Ruhoh
       
       config = Config.new
       config.production_url = site_config['production_url']
-      config.dev_url = site_config['dev_url'] if config.production_url.nil? 
+      config.dev_url = site_config['dev_url'] 
       config.production_url = '/' if config.production_url.nil?
       config.dev_url = '/' if config.dev_url.nil?
       config.theme = theme

--- a/lib/ruhoh/converters/html.rb
+++ b/lib/ruhoh/converters/html.rb
@@ -1,0 +1,14 @@
+class Ruhoh
+  module Converter
+    module Html
+
+      def self.extensions
+        ['.htm', '.html']
+      end
+      
+      def self.convert(content)
+              content
+      end
+    end
+  end
+end

--- a/lib/ruhoh/converters/textile.rb
+++ b/lib/ruhoh/converters/textile.rb
@@ -1,0 +1,15 @@
+class Ruhoh
+  module Converter
+    module Textile
+
+      def self.extensions
+        ['.textile']
+      end
+      
+      def self.convert(content)
+        require 'redcloth'
+        RedCloth.new(content).to_html
+      end
+    end
+  end
+end

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -84,8 +84,10 @@ class Ruhoh
     # Returns: [String] The relative path to the compiled file for this page.
     def compiled_path
       self.ensure_id
-      path = CGI.unescape(@data['url']).gsub(/^\//, '') #strip leading slash.
-      path = "index.html" if path.empty?
+      #path = CGI.unescape(@data['url']).gsub(Regexp.new("^#{Ruhoh.paths.base}/"), '') #strip leading slash.
+      path = CGI.unescape(@data['url']).gsub(Regexp.new("^#{Ruhoh.urls.docroot}/"), '') #strip leading slash.
+      #path = "index.html" if path.gsub(Regexp.new("^#{Ruhoh.paths.base}/"), '').empty?
+      path = "index.html" if path.empty? || path == "index"
       path += '/index.html' unless path =~ /\.\w+$/
       path
     end

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -85,7 +85,7 @@ class Ruhoh
     def compiled_path
       self.ensure_id
       #path = CGI.unescape(@data['url']).gsub(Regexp.new("^#{Ruhoh.paths.base}/"), '') #strip leading slash.
-      path = CGI.unescape(@data['url']).gsub(Regexp.new("^#{Ruhoh.urls.docroot}/"), '') #strip leading slash.
+      path = CGI.unescape(@data['url']).gsub(Regexp.new("^#{Ruhoh.urls.docroot}/*"), '') #strip leading slash.
       #path = "index.html" if path.gsub(Regexp.new("^#{Ruhoh.paths.base}/"), '').empty?
       path = "index.html" if path.empty? || path == "index"
       path += '/index.html' unless path =~ /\.\w+$/

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -65,7 +65,7 @@ class Ruhoh
         name = page['id'].gsub(Regexp.new("#{ext}$"), '')
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
-        url = "#{url}#{ext}".gsub(/\/index.html$/, '')
+        url = "/#{url}#{ext}".gsub(/\/index.html$/, '')#.sub(/\/(.+)/, '\1')
         if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
           url = url.gsub(/\.html$/, '') 
         end

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -65,7 +65,7 @@ class Ruhoh
         name = page['id'].gsub(Regexp.new("#{ext}$"), '')
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
-        url = "/#{url}#{ext}".gsub(/\/index.html$/, '')
+        url = "#{url}#{ext}".gsub(/\/index.html$/, '')
         if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
           url = url.gsub(/\.html$/, '') 
         end

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -65,7 +65,7 @@ class Ruhoh
         name = page['id'].gsub(Regexp.new("#{ext}$"), '')
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
-        url = [ Ruhoh.urls.docroot, "#{url}#{ext}".gsub(/\/index.html$/, '') ].join('/')#.sub(/\/(.+)/, '\1')
+        url = [ Ruhoh.urls.docroot, "#{url}#{ext}".gsub(/\/index.html$/, '') ].join('/').sub(/^\/+/, '/')
         if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
           url = url.gsub(/\.html$/, '') 
         end

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -65,7 +65,7 @@ class Ruhoh
         name = page['id'].gsub(Regexp.new("#{ext}$"), '')
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
-        url = "/#{url}#{ext}".gsub(/\/index.html$/, '')#.sub(/\/(.+)/, '\1')
+        url = [ Ruhoh.urls.docroot, "#{url}#{ext}".gsub(/\/index.html$/, '') ].join('/')#.sub(/\/(.+)/, '\1')
         if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
           url = url.gsub(/\.html$/, '') 
         end

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -66,7 +66,7 @@ class Ruhoh
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
         url = [ Ruhoh.urls.docroot, "#{url}#{ext}".gsub(/\/index.html$/, '') ].join('/').sub(/^\/+/, '/')
-        if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
+        if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty' && page['id'] != "index.html"
           url = url.gsub(/\.html$/, '') 
         end
         url = '/' if url.empty?

--- a/lib/ruhoh/parsers/posts.rb
+++ b/lib/ruhoh/parsers/posts.rb
@@ -160,7 +160,7 @@ class Ruhoh
           "categories" => category || '',
         }.inject(format) { |result, token|
           result.gsub(/:#{Regexp.escape token.first}/, token.last)
-        }.gsub(/\/+/, "/").sub(/^/, "#{Ruhoh.urls.docroot}")#.gsub(/\/+/, '/')
+        }.gsub(/\/+/, "/").sub(/^/, "#{Ruhoh.urls.docroot}").sub(/^\/+/, '/')
 
         url
       end

--- a/lib/ruhoh/parsers/posts.rb
+++ b/lib/ruhoh/parsers/posts.rb
@@ -160,7 +160,7 @@ class Ruhoh
           "categories" => category || '',
         }.inject(format) { |result, token|
           result.gsub(/:#{Regexp.escape token.first}/, token.last)
-        }.gsub(/\/+/, "/").sub(/^/, "#{Ruhoh.urls.docroot}").gsub(/\/+/, '/')
+        }.gsub(/\/+/, "/").sub(/^/, "#{Ruhoh.urls.docroot}")#.gsub(/\/+/, '/')
 
         url
       end

--- a/lib/ruhoh/parsers/posts.rb
+++ b/lib/ruhoh/parsers/posts.rb
@@ -142,7 +142,7 @@ class Ruhoh
         # Use the literal permalink if it is a non-tokenized string.
         unless format.include?(':')
           url = format.gsub(/^\//, '').split('/').map {|p| CGI::escape(p) }.join('/')
-          return "/#{url}"
+          return "#{Ruhoh.urls.docroot}/#{url}"
         end  
 
         filename = File.basename(post['id'], File.extname(post['id']))
@@ -160,7 +160,7 @@ class Ruhoh
           "categories" => category || '',
         }.inject(format) { |result, token|
           result.gsub(/:#{Regexp.escape token.first}/, token.last)
-        }.gsub(/\/+/, "/")
+        }.gsub(/\/+/, "/").sub(/^/, "#{Ruhoh.urls.docroot}").gsub(/\/+/, '/')
 
         url
       end

--- a/lib/ruhoh/previewer.rb
+++ b/lib/ruhoh/previewer.rb
@@ -16,7 +16,7 @@ class Ruhoh
       return favicon if env['PATH_INFO'] == '/favicon.ico'
       return admin if [Ruhoh.urls.dashboard, "#{Ruhoh.urls.dashboard}/"].include?(env['PATH_INFO'])
       
-      id = Ruhoh::DB.routes[env['PATH_INFO']]
+      id = Ruhoh::DB.site['config']['env'] == "production" ? Ruhoh::DB.routes[env['PATH_INFO'].sub(/^\//, "#{Ruhoh.urls.docroot}/")] : Ruhoh::DB.routes[env['PATH_INFO']]
       raise "Page id not found for url: #{env['PATH_INFO']}" unless id
       @page.change(id)
 

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -34,7 +34,7 @@ class Ruhoh
     
     def self.to_url(*args)
             if Ruhoh.config.env == 'production'
-                    args.unshift(nil).join('/').sub(/^\/+/, '')
+                    args.unshift(nil).join('/').sub(/^\/+(http:\/\/.*)/, '\1').sub(/^\/{2,}/, '/')
             else 
                     args.unshift(nil).join('/').sub(/^\/+/, '/')
             end

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -11,25 +11,29 @@ class Ruhoh
       :theme_media,
       :theme_javascripts,
       :theme_stylesheets,
-      :theme_widgets
+      :theme_widgets,
+      :docroot  # For constructing abs url
     )
 
     def self.generate(config)
       urls                      = Urls.new
-      urls.media                = self.to_url(Ruhoh.names.assets, Ruhoh.names.media)
-      urls.widgets              = self.to_url(Ruhoh.names.assets, Ruhoh.names.widgets)
-      urls.dashboard            = self.to_url(Ruhoh.names.dashboard_file.split('.')[0])
+      urls.docroot              = config.env == 'production' ?
+              self.to_url(config.production_url) :
+              self.to_url(config.dev_url)   # not sure if it's ok
+      urls.media                = self.to_url(urls.docroot, Ruhoh.names.assets, Ruhoh.names.media)
+      urls.widgets              = self.to_url(urls.docroot, Ruhoh.names.assets, Ruhoh.names.widgets)
+      urls.dashboard            = self.to_url(urls.docroot, Ruhoh.names.dashboard_file.split('.')[0])
 
-      urls.theme                = self.to_url(Ruhoh.names.assets, config.theme)
-      urls.theme_media          = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.media)
-      urls.theme_javascripts    = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.javascripts)
-      urls.theme_stylesheets    = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.stylesheets)
-      urls.theme_widgets        = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.widgets)
+      urls.theme                = self.to_url(urls.docroot, Ruhoh.names.assets, config.theme)
+      urls.theme_media          = self.to_url(urls.docroot, Ruhoh.names.assets, config.theme, Ruhoh.names.media)
+      urls.theme_javascripts    = self.to_url(urls.docroot, Ruhoh.names.assets, config.theme, Ruhoh.names.javascripts)
+      urls.theme_stylesheets    = self.to_url(urls.docroot, Ruhoh.names.assets, config.theme, Ruhoh.names.stylesheets)
+      urls.theme_widgets        = self.to_url(urls.docroot, Ruhoh.names.assets, config.theme, Ruhoh.names.widgets)
       urls
     end
     
     def self.to_url(*args)
-      args.unshift(nil).join('/').sub(/^\//,"")
+      args.unshift(nil).join('/').sub(/^\/+/, '')
     end
     
     def self.to_url_slug(title)

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -33,7 +33,11 @@ class Ruhoh
     end
     
     def self.to_url(*args)
-      args.unshift(nil).join('/').sub(/^\/+/, '')
+            if Ruhoh.config.env == 'production'
+                    args.unshift(nil).join('/').sub(/^\/+/, '')
+            else 
+                    args.unshift(nil).join('/').sub(/^\/+/, '/')
+            end
     end
     
     def self.to_url_slug(title)

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -29,7 +29,7 @@ class Ruhoh
     end
     
     def self.to_url(*args)
-      args.unshift(nil).join('/')
+      args.unshift(nil).join('/').sub(/^\//,"")
     end
     
     def self.to_url_slug(title)

--- a/lib/ruhoh/utils.rb
+++ b/lib/ruhoh/utils.rb
@@ -64,7 +64,7 @@ class Ruhoh
     end
 
     def self.url_to_path(url, base=nil)
-      parts = url.split('/')
+      parts = url.sub(Regexp.new("^#{Ruhoh.urls.docroot}/"), '').split('/')
       parts = parts.unshift(base) if base
       File.__send__(:join, parts)
     end    


### PR DESCRIPTION
Hi, first please allow me to thank you for bringing ruhoh.

When I deploy ruhoh to my VPS on Linode, I encountered a problem: my blog sits at http://idenizen.net/blog, for testing purposes, I decided to put ruhoh compiled files under http://idenizen.net/ruhoh.  When I browse the url, I find that all asset links and permalinks are all pointing to /, e.g. http://idenizen.net/assets/... .  It seems that although you have `production_url` in `config.yml`, the urls generated doesn't respect this variable.  This can be circumvented by using a virtual host, but currently that's not my idea about my website.

Thus I changed the files a bit, mostly under `lib/ruhoh`, to make ruhoh recognize the path it is in on the server.  Moreover, I set up another variable in `config.yml` in my ruhoh blog, namely `dev_url`.  Both `production_url` and `dev_url` defaults to `/`, and when `config.env` is set to `production`, `production_url` overrides `dev_url`, otherwise `dev_url` is used when `config.env` is set to anything else.  This enables one to preview changes to the blog locally, and by switching to `production`, one can easily upload the results to the production server.  Please see celadevra/celadevra.ruhoh.com@bb49362 for my config.  Also, I find that after these changes, the `div.navbar>div.navbar-inner>a.brand` doesn't give the correct root url, therefore I also changed the layout under the theme a bit, please see the above blob as well.

I tested these changes with my own blog, both locally and on my VPS.  As you may already find out, I am not too familiar with Ruby (I learn some of it from your code :), so please indulge me for bugs.  Also, if ruhoh as of now actually supports deploying to places like somehost.com/your/path, please let me know how.  Much appreciated.
