### PR TITLE
Make # of RSS Posts Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
+## My Ruhoh
 
-## Ruhoh is the Universal Static Blog API
+This fork of the ruhoh blogging engine is for my fiddling with various 
+features.  For more info, see:
 
 <http://ruhoh.com>
 
-### Usage
+Here are some of the features I'm working on:
 
-    $ gem install ruhoh
-    $ ruhoh help
+### RSS Limit
+
+A new config option allows you to limit the number of posts included in 
+the RSS feed.  Default behavior is to include all posts.
+
+   posts:
+     ...
+     rss_limit: 10
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Here are some of the features I'm working on:
 A new config option allows you to limit the number of posts included in 
 the RSS feed.  Default behavior is to include all posts.
 
-   posts:
-     ...
-     rss_limit: 10
+   rss:
+     limit: 10
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Here are some of the features I'm working on:
 A new config option allows you to limit the number of posts included in 
 the RSS feed.  Default behavior is to include all posts.
 
-   rss:
-     limit: 10
+    rss:
+      limit: 10
 

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -71,6 +71,7 @@ class Ruhoh
     return false unless(@config && @paths && @urls)
     
     self.setup_plugins unless opts[:enable_plugins] == false
+    self.setup_widgets unless opts[:enable_plugins] == false
     true
   end
   
@@ -81,6 +82,11 @@ class Ruhoh
   def self.setup_plugins
     plugins = Dir[File.join(self.paths.plugins, "**/*.rb")]
     plugins.each {|f| require f } unless plugins.empty?
+  end
+  
+  def self.setup_widgets
+    widgets = Dir[File.join(self.paths.widgets, "**/*.rb")]
+    widgets.each {|f| require f } unless widgets.empty?
   end
   
   def self.ensure_setup

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -10,12 +10,9 @@ class Ruhoh
       # render the content to save to disk. This will be a problem when
       # posts numbers expand. Merge this in later.
       def self.run(target, page)
-        num_posts = Ruhoh::DB.site['config']['posts']['rss_limit']
-        if (num_posts == nil)
-           posts = Ruhoh::DB.posts['chronological']
-        else
-           posts = Ruhoh::DB.posts['chronological'][1,num_posts]
-        end
+        num_posts = Ruhoh.config.rss_limit
+        Ruhoh::Friend.say { green num_posts }
+        posts = Ruhoh::DB.posts['chronological'].first(num_posts)
 
         feed = Nokogiri::XML::Builder.new do |xml|
          xml.rss(:version => '2.0') {

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -11,7 +11,6 @@ class Ruhoh
       # posts numbers expand. Merge this in later.
       def self.run(target, page)
         num_posts = Ruhoh.config.rss_limit
-        Ruhoh::Friend.say { green num_posts }
         posts = Ruhoh::DB.posts['chronological'].first(num_posts)
 
         feed = Nokogiri::XML::Builder.new do |xml|

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -10,13 +10,20 @@ class Ruhoh
       # render the content to save to disk. This will be a problem when
       # posts numbers expand. Merge this in later.
       def self.run(target, page)
+        num_posts = Ruhoh::DB.site['config']['posts']['rss_limit']
+        if (num_posts == nil)
+           posts = Ruhoh::DB.posts['chronological']
+        else
+           posts = Ruhoh::DB.posts['chronological'][1,num_posts]
+        end
+
         feed = Nokogiri::XML::Builder.new do |xml|
          xml.rss(:version => '2.0') {
            xml.channel {
              xml.title_ Ruhoh::DB.site['title']
              xml.link_ Ruhoh::DB.site['config']['production_url']
-             xml.pubDate_ Time.now
-             Ruhoh::DB.posts['chronological'].each do |post_id|
+             xml.pubDate_ Time.now          
+             posts.each do |post_id|
                post = Ruhoh::DB.posts['dictionary'][post_id]
                page.change(post_id)
                xml.item {

--- a/lib/ruhoh/config.rb
+++ b/lib/ruhoh/config.rb
@@ -9,6 +9,7 @@ class Ruhoh
       :posts_exclude,
       :posts_layout,
       :posts_permalink,
+      :rss_limit,
       :theme
     )
 
@@ -28,7 +29,10 @@ class Ruhoh
       config = Config.new
       config.theme = theme
       config.env = site_config['env'] || nil
-      
+
+      config.rss_limit = site_config['rss']['limit'] rescue nil
+      config.rss_limit = 20 if config.rss_limit.nil?
+
       config.posts_permalink = site_config['posts']['permalink'] rescue nil
       config.posts_layout = site_config['posts']['layout'] rescue nil
       config.posts_layout = 'post' if config.posts_layout.nil?

--- a/lib/ruhoh/parsers/widgets.rb
+++ b/lib/ruhoh/parsers/widgets.rb
@@ -61,15 +61,15 @@ class Ruhoh
       #
       # Returns Array of script filenames to load.
       def self.process_javascripts(config, widget_name)
-        scripts = config[Ruhoh.names.javascripts] ? Array(config[Ruhoh.names.javascripts]) : []
-        
+        scripts = config[Ruhoh.names.javascripts] ? Array(config[Ruhoh.names.javascripts].split(/\s/)) : []
+                                
         # Try for the default script if no config.
         if scripts.empty?
           script_file = File.join(Ruhoh.paths.widgets, widget_name, Ruhoh.names.javascripts, "#{widget_name}.js")
           if File.exist?(script_file)
             scripts << "#{widget_name}.js"
           else
-            script_file = File.join(Ruhoh.paths.system_widgets, widget_name, Ruhoh.names.javascripts, "#{widget_name}.js")
+            script_file = File.join(Ruhoh.paths.system_widgets, widget_name, Ruhoh.names.javascripts, "#{widget_name}.js")                      
             scripts << "#{widget_name}.js" if File.exist?(script_file)
           end
         end


### PR DESCRIPTION
Seems like celadevra and I ran into a similar issue with wanting to limit the # of RSS posts (his is issue #48).  I put in a little more error-checking and integrated it into the man config object, so I'm putting in a separate pull request.
