### PR TITLE
Widgets can't have multiple javascripts?

### DIFF
--- a/lib/ruhoh/parsers/widgets.rb
+++ b/lib/ruhoh/parsers/widgets.rb
@@ -61,7 +61,7 @@ class Ruhoh
       #
       # Returns Array of script filenames to load.
       def self.process_javascripts(config, widget_name)
-        scripts = config[Ruhoh.names.javascripts] ? Array(config[Ruhoh.names.javascripts]) : []
+        scripts = config[Ruhoh.names.javascripts] ? Array(config[Ruhoh.names.javascripts].split(/\s/)) : []
         
         # Try for the default script if no config.
         if scripts.empty?


### PR DESCRIPTION
Seems that the widget parser doesn't handle a widget with multiple javascript files -- unless perhaps I'm missing something.  I tried various permutations.  

I made a change in my fork to make it accept multiple JS files separated by spaces, like so:

```
In widgets/mywidget/config.yml:
javascripts:   
  x.js
  y.js 
  z.js
```

   (could also be x.js y.js z.js -- though I didn't test that explicitly)
