### PR TITLE
Widget Enhancements - Helpers and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## My Ruhoh
+# My Ruhoh
 
 This fork of the ruhoh blogging engine is for my fiddling with various 
 features.  For more info, see:
@@ -7,11 +7,24 @@ features.  For more info, see:
 
 Here are some of the features I'm working on:
 
-### RSS Limit
+## RSS Limit
 
 A new config option allows you to limit the number of posts included in 
 the RSS feed.  Default behavior is to include all posts.
 
     rss:
       limit: 10
+
+## Widget Enhancements
+
+### Widget Helpers
+
+Widgets can now have Ruby helpers, which should be located in a 'helpers'
+folder under the widget and named with the ".rb" extension.
+
+    widgets
+       my_widget
+           helpers
+           javascripts
+           layouts
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ folder under the widget and named with the ".rb" extension.
            javascripts
            layouts
 
+### Widget Context
+
+Widget layouts now have access to the current page context, just like other 
+layouts and partials.
+
+Note: As a side effect of this, the special "{{config}}" that widgets
+used to have passed directly is now part of the global payload under
+"{{widgets.<widgetname>.config}}"

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -71,6 +71,7 @@ class Ruhoh
     return false unless(@config && @paths && @urls)
     
     self.setup_plugins unless opts[:enable_plugins] == false
+    self.setup_widgets unless opts[:enable_plugins] == false
     true
   end
   
@@ -81,6 +82,11 @@ class Ruhoh
   def self.setup_plugins
     plugins = Dir[File.join(self.paths.plugins, "**/*.rb")]
     plugins.each {|f| require f } unless plugins.empty?
+  end
+  
+  def self.setup_widgets
+   	widgets = Dir[File.join(self.paths.widgets, "**/*.rb")]
+   	widgets.each {|f| require f } unless widgets.empty?
   end
   
   def self.ensure_setup

--- a/lib/ruhoh/parsers/payload.rb
+++ b/lib/ruhoh/parsers/payload.rb
@@ -3,6 +3,7 @@ class Ruhoh
     module Payload
       
       def self.generate
+        payload = 
         {
           "db" => {
             "pages" =>  Ruhoh::DB.pages,
@@ -15,8 +16,21 @@ class Ruhoh
             "theme_javascripts" => Ruhoh.urls.theme_javascripts,
             "theme_media" => Ruhoh.urls.theme_media,
             "media" => Ruhoh.urls.media,
-          }
+          },
+          "widgets" => {}
         }
+        self.merge_widget_config(payload)
+        payload
+      end
+      
+      def self.merge_widget_config(payload)
+        return if Ruhoh::DB.widgets == nil
+        Ruhoh::DB.widgets.each do |widget_arr|
+          name = widget_arr[0]
+          config = widget_arr[1]['config']
+          
+          payload['widgets'][name] = { 'config' => config }
+        end
       end
       
       # This is an ugly hack to determine the proper category and tag urls.

--- a/lib/ruhoh/parsers/widgets.rb
+++ b/lib/ruhoh/parsers/widgets.rb
@@ -23,7 +23,6 @@ class Ruhoh
           )
         end
         Ruhoh::Utils.report('Widgets', widgets, [])
-
         widgets
       end
 
@@ -62,7 +61,6 @@ class Ruhoh
       # Returns Array of script filenames to load.
       def self.process_javascripts(config, widget_name)
         scripts = config[Ruhoh.names.javascripts] ? Array(config[Ruhoh.names.javascripts]) : []
-        
         # Try for the default script if no config.
         if scripts.empty?
           script_file = File.join(Ruhoh.paths.widgets, widget_name, Ruhoh.names.javascripts, "#{widget_name}.js")
@@ -96,9 +94,8 @@ class Ruhoh
 
         return '' unless layout
         content = File.open(layout, 'r:UTF-8') { |f| f.read }
-        Mustache.render(content, {'config' => config})
-      end
-      
+        content
+      end  
     end #Widgets
   end #Parsers
 end #Ruhoh

--- a/lib/ruhoh/templaters/rmustache.rb
+++ b/lib/ruhoh/templaters/rmustache.rb
@@ -19,7 +19,6 @@ class Ruhoh
 
           self.mustache_in_stack.__send__ helper, context
         end  
-
       end #RContext
   
       def context
@@ -52,7 +51,8 @@ class Ruhoh
       
       def widget(name)
         return '' if self.context['page'][name.to_s].to_s == 'false'
-        Ruhoh::DB.widgets[name.to_s]['layout']
+        raw_layout = Ruhoh::DB.widgets[name.to_s]['layout']
+        self.render(raw_layout)
       end
       
       def method_missing(name, *args, &block)

--- a/widgets/analytics/layouts/getclicky.html
+++ b/widgets/analytics/layouts/getclicky.html
@@ -1,6 +1,6 @@
 <script>
 var clicky_site_ids = clicky_site_ids || [];
-clicky_site_ids.push({{ config.getclicky.site_id }});
+clicky_site_ids.push({{ widgets.analytics.config.getclicky.site_id }});
 (function() {
   var s = document.createElement('script');
   s.type = 'text/javascript';
@@ -9,4 +9,4 @@ clicky_site_ids.push({{ config.getclicky.site_id }});
   ( document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0] ).appendChild( s );
 })();
 </script>
-<noscript><p><img alt="Clicky" width="1" height="1" src="//in.getclicky.com/{{ config.getclicky.site_id }}ns.gif" /></p></noscript>
+<noscript><p><img alt="Clicky" width="1" height="1" src="//in.getclicky.com/{{ widgets.analytics.config.getclicky.site_id }}ns.gif" /></p></noscript>

--- a/widgets/analytics/layouts/google.html
+++ b/widgets/analytics/layouts/google.html
@@ -1,5 +1,5 @@
 <script>
-  var _gaq=[['_setAccount','{{ config.google.tracking_id }}'],['_trackPageview']];
+  var _gaq=[['_setAccount','{{ widgets.analytics.config.google.tracking_id }}'],['_trackPageview']];
   (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
   g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
   s.parentNode.insertBefore(g,s)}(document,'script'));

--- a/widgets/comments/layouts/disqus.html
+++ b/widgets/comments/layouts/disqus.html
@@ -1,7 +1,7 @@
 <div id="disqus_thread"></div>
 <script>
     {{^production }}var disqus_developer = 1;{{/production}}
-    var disqus_shortname = '{{ config.disqus.short_name }}'; // required: replace example with your forum shortname
+    var disqus_shortname = '{{ widgets.comments.config.disqus.short_name }}'; // required: replace example with your forum shortname
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;

--- a/widgets/comments/layouts/facebook.html
+++ b/widgets/comments/layouts/facebook.html
@@ -3,7 +3,7 @@
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId={{ site.config.comments.facebook.appid }}";
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId={{ widgets.comments.config.facebook.appid }}";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
-<div class="fb-comments" data-href="{{ site.production_url }}" data-num-posts="{{ config.comments.facebook.num_posts }}" data-width="{{ config.comments.facebook.width }}" data-colorscheme="{{ config.comments.facebook.colorscheme }}"></div>
+<div class="fb-comments" data-href="{{ site.production_url }}" data-num-posts="{{ widgets.comments.config.facebook.num_posts }}" data-width="{{ widgets.comments.config.facebook.width }}" data-colorscheme="{{ widgets.comments.config.facebook.colorscheme }}"></div>

--- a/widgets/comments/layouts/intensedebate.html
+++ b/widgets/comments/layouts/intensedebate.html
@@ -1,5 +1,5 @@
 <script>
-var idcomments_acct = '{{ config.comments.intensedebate.account }}';
+var idcomments_acct = '{{ widgets.comments.config.intensedebate.account }}';
 var idcomments_post_id;
 var idcomments_post_url;
 </script>

--- a/widgets/comments/layouts/livefyre.html
+++ b/widgets/comments/layouts/livefyre.html
@@ -1,6 +1,6 @@
 <script type='text/javascript' src='http://zor.livefyre.com/wjs/v1.0/javascripts/livefyre_init.js'></script>
 <script type='text/javascript'>
     var fyre = LF({
-        site_id: {{ config.comments.livefyre.site_id }}
+        site_id: {{ widgets.comments.config.livefyre.site_id }}
     });
 </script>

--- a/widgets/google_prettify/layouts/google_prettify.html
+++ b/widgets/google_prettify/layouts/google_prettify.html
@@ -3,7 +3,7 @@
 <script>
   var pres = document.getElementsByTagName("pre");
   for (var i=0; i < pres.length; ++i) {
-    pres[i].className = "prettyprint {{# config.linenums }}linenums{{/config.linenums}}";
+    pres[i].className = "prettyprint {{# widgets.google_prettify.config.linenums }}linenums{{/widgets.google_prettify.config.linenums}}";
   }
   prettyPrint();
 </script>


### PR DESCRIPTION
This pull request addresses issues #52 and #53.

**Widget Helpers**

Widgets can now have Ruby helpers, which should be located in a 'helpers' folder under the widget and named with the ".rb" extension.

```
widgets
   my_widget
       helpers
          my_widget.rb
       javascripts
       layouts
```

_Note:  This blurs the line between what is a 'plugin' and what is a 'widget', but I'm not sure if that's bad.  By allowing you to do both, I think it offers more flexibility._

**Widget Context**

Widget layouts now have access to the current page context, just like other layouts and partials.

_Note: As a side effect of this, the special "{{config}}" that widgets used to have passed directly is now part of the global payload under "{{widgets.widget_name.config}}"   There's an easy way to fix this, so that {{config}} is there for backwards-compatibility, but since I knew you were fixing up the widget config references somewhat in the next release anyway, I wasn't sure it was a big deal._
