### PR TITLE
Conditionally require the psych gem.  It's included in ruby 1.9.2 or better.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rack', "~> 1.4"
 gem 'directory_watcher', "~> 1.4"
-gem 'psych', "~> 1.3"
+gem 'psych', "~> 1.3", :platforms => [:ruby_18, :mingw_18]
 gem 'redcarpet', "~> 2.1"
 gem 'nokogiri', "~> 1.5"
 

--- a/ruhoh.gemspec
+++ b/ruhoh.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'mustache', "~> 0.99"
   s.add_dependency 'directory_watcher', "~> 1.4"
   s.add_dependency 'redcarpet', "~> 2.1"
-  s.add_dependency 'psych', "~> 1.3"
   s.add_dependency 'nokogiri', "~> 1.5"
   
   # = MANIFEST =
@@ -52,6 +51,7 @@ Gem::Specification.new do |s|
     lib/ruhoh/parsers/routes.rb
     lib/ruhoh/parsers/site.rb
     lib/ruhoh/parsers/stylesheets.rb
+    lib/ruhoh/parsers/theme_config.rb
     lib/ruhoh/parsers/widgets.rb
     lib/ruhoh/paths.rb
     lib/ruhoh/previewer.rb


### PR DESCRIPTION
The **psych** library [ships with Ruby 1.9.2 or greater](http://www.ruby-lang.org/en/news/2010/08/18/ruby-1-9.2-released/).  Unfortunately, it seems there is no way to conditionally add a dependency to `ruhoh.gemspec`, so this solution attempts a compromise by removing the dependency in the **gemspec** and adding the conditional dependency for bundler's **Gemfile**.  This means users with ruby 1.8.x will be prompted to manually install _psych_ when they run _ruhoh_ for the first time.  I got the idea from [this article](http://blog.mattwynne.net/2011/04/26/targeting-multiple-platforms-jruby-etc-with-a-rubygems-gemspec/).

What motivates me to do this is to resolve #54 (at least partially).  The latest 1.9.x RubyInstaller includes **psych**, so Windows users with a recent version of ruby will be able to install and run _ruhoh_ without going through the trouble of hacking the **psych** gem in order to install it.
