### PR TITLE
1.0.rc - New Features for your consideration

### DIFF
--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -30,7 +30,7 @@ class Ruhoh
   
   class << self
     attr_accessor :log
-    attr_reader :config, :names, :paths, :root, :urls
+    attr_reader :config, :names, :paths, :root, :urls, :base
   end
   
   @log = Ruhoh::Logger.new
@@ -63,28 +63,49 @@ class Ruhoh
     self.reset
     @log.log_file = opts[:log_file] if opts[:log_file]
     @base = opts[:source] if opts[:source]
-    
-    @config   = Ruhoh::Config.generate(@names.config_data)
-    @paths    = Ruhoh::Paths.generate(@config, @base)
-    @urls     = Ruhoh::Urls.generate(@config)
-
-    return false unless(@config && @paths && @urls)
-    
-    self.setup_plugins unless opts[:enable_plugins] == false
-    true
+    @config = Ruhoh::Config.generate(@names.config_data)
+    !!@config
   end
   
   def self.reset
     @base = Dir.getwd
   end
   
+  def self.setup_paths
+    self.ensure_config
+    @paths = Ruhoh::Paths.generate
+  end
+
+  def self.setup_urls
+    self.ensure_config
+    @urls = Ruhoh::Urls.generate
+  end
+  
   def self.setup_plugins
+    self.ensure_paths
     plugins = Dir[File.join(self.paths.plugins, "**/*.rb")]
     plugins.each {|f| require f } unless plugins.empty?
   end
   
   def self.ensure_setup
-    raise 'Ruhoh has not been setup. Please call: Ruhoh.setup' unless Ruhoh.config && Ruhoh.paths
+    return if Ruhoh.config && Ruhoh.paths && Ruhoh.urls
+    raise 'Ruhoh has not been fully setup. Please call: Ruhoh.setup'
   end  
+  
+  def self.ensure_config
+    return if Ruhoh.config
+    raise 'Ruhoh has not setup config. Please call: Ruhoh.setup'
+  end  
+
+  def self.ensure_paths
+    return if Ruhoh.config && Ruhoh.paths
+    raise 'Ruhoh has not setup paths. Please call: Ruhoh.setup'
+  end  
+  
+  def self.ensure_urls
+    return if Ruhoh.config && Ruhoh.urls
+    raise 'Ruhoh has not setup urls. Please call: Ruhoh.setup + Ruhoh.setup_urls' 
+  end  
+  
   
 end # Ruhoh

--- a/lib/ruhoh/client/client.rb
+++ b/lib/ruhoh/client/client.rb
@@ -17,7 +17,11 @@ class Ruhoh
         exit 
       } unless self.respond_to?(cmd)
 
-      Ruhoh.setup unless ['help','blog','compile'].include?(cmd)
+      unless ['help','blog','compile'].include?(cmd)
+        Ruhoh.setup
+        Ruhoh.setup_paths
+        Ruhoh.setup_urls
+      end  
 
       self.__send__(cmd)
     end  

--- a/lib/ruhoh/compiler.rb
+++ b/lib/ruhoh/compiler.rb
@@ -26,6 +26,7 @@ class Ruhoh
       def self.run(target, page)
         self.pages(target, page)
         self.media(target, page)
+        self.javascripts(target, page)
       end
       
       def self.pages(target, page)
@@ -47,6 +48,22 @@ class Ruhoh
         media = Ruhoh::Utils.url_to_path(url, target)
         FileUtils.mkdir_p media
         FileUtils.cp_r File.join(Ruhoh.paths.media, '.'), media
+      end
+      
+      # Create all the javascripts.
+      # Javascripts may be registered from either a theme or a widget.
+      # Technically the theme compiler may create javascripts relative to the theme.
+      # This ensures the widget javascripts are created as well.
+      def self.javascripts(target, page)
+        Ruhoh::DB.javascripts.each do |type, assets|
+          assets.each do |asset|
+            url = asset['url'].gsub(/^\//, '')
+            next unless File.exist?(asset['id'])
+            file_path = Ruhoh::Utils.url_to_path(File.dirname(url), target)
+            FileUtils.mkdir_p file_path
+            FileUtils.cp(asset['id'], file_path)
+          end
+        end
       end
       
     end #Defaults

--- a/lib/ruhoh/compiler.rb
+++ b/lib/ruhoh/compiler.rb
@@ -43,7 +43,8 @@ class Ruhoh
       
       def self.media(target, page)
         return unless FileTest.directory? Ruhoh.paths.media
-        media = Ruhoh::Utils.url_to_path(Ruhoh.urls.media, target)
+        url = Ruhoh.urls.media.gsub(/^\//, '')
+        media = Ruhoh::Utils.url_to_path(url, target)
         FileUtils.mkdir_p media
         FileUtils.cp_r File.join(Ruhoh.paths.media, '.'), media
       end

--- a/lib/ruhoh/compilers/theme.rb
+++ b/lib/ruhoh/compilers/theme.rb
@@ -11,8 +11,9 @@ class Ruhoh
       def self.stylesheets(target, page)
         Ruhoh::DB.stylesheets.each do |type, assets|
           assets.each do |asset|
+            url = asset['url'].gsub(/^\//, '')
             next unless File.exist?(asset['id'])
-            file_path = Ruhoh::Utils.url_to_path(File.dirname(asset['url']), target)
+            file_path = Ruhoh::Utils.url_to_path(File.dirname(url), target)
             FileUtils.mkdir_p file_path
             FileUtils.cp(asset['id'], file_path)
           end
@@ -22,8 +23,9 @@ class Ruhoh
       def self.javascripts(target, page)
         Ruhoh::DB.javascripts.each do |type, assets|
           assets.each do |asset|
+            url = asset['url'].gsub(/^\//, '')
             next unless File.exist?(asset['id'])
-            file_path = Ruhoh::Utils.url_to_path(File.dirname(asset['url']), target)
+            file_path = Ruhoh::Utils.url_to_path(File.dirname(url), target)
             FileUtils.mkdir_p file_path
             FileUtils.cp(asset['id'], file_path)
           end
@@ -32,7 +34,8 @@ class Ruhoh
       
       def self.media(target, page)
         return unless FileTest.directory? Ruhoh.paths.theme_media
-        theme_media = Ruhoh::Utils.url_to_path(Ruhoh.urls.theme_media, target)
+        url = Ruhoh.urls.theme_media.gsub(/^\//, '')
+        theme_media = Ruhoh::Utils.url_to_path(url, target)
         FileUtils.mkdir_p theme_media
         FileUtils.cp_r File.join(Ruhoh.paths.theme_media, '.'), theme_media
       end

--- a/lib/ruhoh/compilers/theme.rb
+++ b/lib/ruhoh/compilers/theme.rb
@@ -3,42 +3,44 @@ class Ruhoh
     module Theme
       
       def self.run(target, page)
-        self.stylesheets(target, page)
-        self.javascripts(target, page)
-        self.media(target, page)
-      end
-      
-      def self.stylesheets(target, page)
-        Ruhoh::DB.stylesheets.each do |type, assets|
-          assets.each do |asset|
-            url = asset['url'].gsub(/^\//, '')
-            next unless File.exist?(asset['id'])
-            file_path = Ruhoh::Utils.url_to_path(File.dirname(url), target)
-            FileUtils.mkdir_p file_path
-            FileUtils.cp(asset['id'], file_path)
-          end
-        end
+        self.copy(target, page)
       end
 
-      def self.javascripts(target, page)
-        Ruhoh::DB.javascripts.each do |type, assets|
-          assets.each do |asset|
-            url = asset['url'].gsub(/^\//, '')
-            next unless File.exist?(asset['id'])
-            file_path = Ruhoh::Utils.url_to_path(File.dirname(url), target)
-            FileUtils.mkdir_p file_path
-            FileUtils.cp(asset['id'], file_path)
-          end
+      # Copies all theme assets over to the compiled site.
+      # Note the compiled assets are namespaced at /assets/<theme-name>/
+      # theme.yml may specify exclusion rules for excluding assets.
+      def self.copy(target, page)
+        url = Ruhoh.urls.theme.gsub(/^\//, '')
+        theme = Ruhoh::Utils.url_to_path(url, target)
+        FileUtils.mkdir_p theme
+
+        self.files.each do |file|
+          original_file = File.join(Ruhoh.paths.theme, file)
+          compiled_file = File.join(theme, file)
+          FileUtils.mkdir_p File.dirname(compiled_file)
+          FileUtils.cp_r original_file, compiled_file
         end
       end
       
-      def self.media(target, page)
-        return unless FileTest.directory? Ruhoh.paths.theme_media
-        url = Ruhoh.urls.theme_media.gsub(/^\//, '')
-        theme_media = Ruhoh::Utils.url_to_path(url, target)
-        FileUtils.mkdir_p theme_media
-        FileUtils.cp_r File.join(Ruhoh.paths.theme_media, '.'), theme_media
+      # Returns list of all files from the theme that need to be
+      # compiled to the production environment.
+      # Returns Array of relative filepaths
+      def self.files
+        FileUtils.cd(Ruhoh.paths.theme) {
+          return Dir["**/*"].select { |filepath|
+            next unless self.is_valid_asset?(filepath)
+            true
+          }
+        }
       end
+
+      # Checks a given asset filepath against any user-defined exclusion rules in theme.yml
+      def self.is_valid_asset?(filepath)
+        return false if FileTest.directory?(filepath)
+        Ruhoh::DB.theme_config["exclude"].each {|regex| return false if filepath =~ regex }
+        true
+      end
+      
     end #Theme
   end #Compiler
 end #Ruhoh

--- a/lib/ruhoh/config.rb
+++ b/lib/ruhoh/config.rb
@@ -10,7 +10,8 @@ class Ruhoh
       :posts_layout,
       :posts_permalink,
       :rss_limit,
-      :theme
+      :theme,
+      :base_path
     )
 
     def self.generate(path_to_config)
@@ -28,8 +29,15 @@ class Ruhoh
       
       config = Config.new
       config.theme = theme
+      
       config.env = site_config['env'] || nil
 
+      config.base_path = '/'
+      if site_config['base_path']
+        config.base_path = site_config['base_path'].to_s
+        config.base_path += "/" unless config.base_path[-1] == '/'
+      end
+      
       config.rss_limit = site_config['rss']['limit'] rescue nil
       config.rss_limit = 20 if config.rss_limit.nil?
 

--- a/lib/ruhoh/db.rb
+++ b/lib/ruhoh/db.rb
@@ -4,6 +4,7 @@ require 'ruhoh/parsers/routes'
 require 'ruhoh/parsers/layouts'
 require 'ruhoh/parsers/partials'
 require 'ruhoh/parsers/widgets'
+require 'ruhoh/parsers/theme_config'
 require 'ruhoh/parsers/stylesheets'
 require 'ruhoh/parsers/javascripts'
 require 'ruhoh/parsers/payload'
@@ -12,7 +13,7 @@ require 'ruhoh/parsers/site'
 class Ruhoh
   # Public: Database class for interacting with "data" in Ruhoh.
   class DB
-    WhiteList = [:site, :posts, :pages, :routes, :layouts, :partials, :widgets, :stylesheets, :javascripts, :payload]
+    WhiteList = [:site, :posts, :pages, :routes, :layouts, :partials, :widgets, :theme_config, :stylesheets, :javascripts, :payload]
 
     class << self
       self.__send__ :attr_reader, *WhiteList
@@ -34,6 +35,8 @@ class Ruhoh
             Ruhoh::Parsers::Partials.generate
           when :widgets
             Ruhoh::Parsers::Widgets.generate
+          when :theme_config
+            Ruhoh::Parsers::ThemeConfig.generate
           when :stylesheets
             Ruhoh::Parsers::Stylesheets.generate
           when :javascripts

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -86,7 +86,7 @@ class Ruhoh
       self.ensure_id
       path = CGI.unescape(@data['url']).gsub(/^\//, '') #strip leading slash.
       path = "index.html" if path.empty?
-      path += '/index.html' unless path =~ /\.\w+$/
+      path += 'index.html' unless path =~ /\.\w+$/
       path
     end
     

--- a/lib/ruhoh/parsers/javascripts.rb
+++ b/lib/ruhoh/parsers/javascripts.rb
@@ -8,16 +8,15 @@ class Ruhoh
       # Generates mappings to all registered javascripts.
       # Returns Hash with layout names as keys and Array of asset Objects as values
       def self.generate
-        theme_config = self.theme_config
-        assets = self.theme_javascripts(theme_config)
-        assets[Ruhoh.names.widgets] = self.widget_javascripts(theme_config)
+        assets = self.theme_javascripts
+        assets[Ruhoh.names.widgets] = self.widget_javascripts
         assets
       end
 
-      def self.theme_javascripts(theme_config)
-        return {} unless theme_config[Ruhoh.names.javascripts].is_a? Hash
+      def self.theme_javascripts
+        return {} unless Ruhoh::DB.theme_config[Ruhoh.names.javascripts].is_a? Hash
         assets = {}
-        theme_config[Ruhoh.names.javascripts].each do |key, value|
+        Ruhoh::DB.theme_config[Ruhoh.names.javascripts].each do |key, value|
           next if key == Ruhoh.names.widgets # Widgets are handled separately.
           assets[key] = Array(value).map { |v|
             {
@@ -35,7 +34,7 @@ class Ruhoh
       #   This differs from the auto-stylesheet inclusion relative to themes, 
       #   which is handled in the stylesheet parser.
       #   Make sure there are some standards with this.
-      def self.widget_javascripts(theme_config)
+      def self.widget_javascripts
         assets = []
         Ruhoh::DB.widgets.each_value do |widget|
           next unless widget[Ruhoh.names.javascripts]
@@ -50,18 +49,6 @@ class Ruhoh
         assets
       end
       
-      def self.theme_config
-        theme_config = Ruhoh::Utils.parse_yaml_file(Ruhoh.paths.theme_config_data)
-        if theme_config.nil?
-          Ruhoh::Friend.say{ 
-            yellow "WARNING: theme.yml config file not found:"
-            yellow "  #{Ruhoh.paths.theme_config_data}"
-          }
-          return {}
-        end
-        return {} unless theme_config.is_a? Hash
-        theme_config
-      end
     end #Javascripts
   end #Parsers
 end #Ruhoh

--- a/lib/ruhoh/parsers/javascripts.rb
+++ b/lib/ruhoh/parsers/javascripts.rb
@@ -19,8 +19,9 @@ class Ruhoh
         Ruhoh::DB.theme_config[Ruhoh.names.javascripts].each do |key, value|
           next if key == Ruhoh.names.widgets # Widgets are handled separately.
           assets[key] = Array(value).map { |v|
+            url = (v =~ /^(http:|https:)?\/\//i) ? v : "#{Ruhoh.urls.theme_javascripts}/#{v}"
             {
-              "url" => "#{Ruhoh.urls.theme_javascripts}/#{v}",
+              "url" => url,
               "id" => File.join(Ruhoh.paths.theme_javascripts, v)
             }
           }

--- a/lib/ruhoh/parsers/pages.rb
+++ b/lib/ruhoh/parsers/pages.rb
@@ -65,10 +65,12 @@ class Ruhoh
         name = page['id'].gsub(Regexp.new("#{ext}$"), '')
         ext = '.html' if Ruhoh::Converter.extensions.include?(ext)
         url = name.split('/').map {|p| Ruhoh::Urls.to_url_slug(p) }.join('/')
-        url = "/#{url}#{ext}".gsub(/\/index.html$/, '')
+        url = "#{url}#{ext}".gsub(/index.html$/, '')
         if page['permalink'] == 'pretty' || Ruhoh.config.pages_permalink == 'pretty'
-          url = url.gsub(/\.html$/, '') 
+          url = url.gsub(/\.html$/, '/') 
         end
+        
+        url = "#{Ruhoh.config.base_path}#{url}"
         url = '/' if url.empty?
 
         url

--- a/lib/ruhoh/parsers/payload.rb
+++ b/lib/ruhoh/parsers/payload.rb
@@ -11,6 +11,7 @@ class Ruhoh
           "site" => Ruhoh::DB.site,
           'page' => {},
           "urls" => {
+            "theme" => Ruhoh.urls.theme,
             "theme_stylesheets" => Ruhoh.urls.theme_stylesheets,
             "theme_javascripts" => Ruhoh.urls.theme_javascripts,
             "theme_media" => Ruhoh.urls.theme_media,

--- a/lib/ruhoh/parsers/payload.rb
+++ b/lib/ruhoh/parsers/payload.rb
@@ -15,6 +15,7 @@ class Ruhoh
             "theme_javascripts" => Ruhoh.urls.theme_javascripts,
             "theme_media" => Ruhoh.urls.theme_media,
             "media" => Ruhoh.urls.media,
+            "base_path" => Ruhoh.config.base_path,
           }
         }
       end
@@ -24,7 +25,7 @@ class Ruhoh
       def self.determine_category_and_tag_urls
         return nil unless Ruhoh::DB.routes && Ruhoh::DB.posts
         categories_url = nil
-        ['/categories', '/categories.html'].each { |url|
+        ["#{Ruhoh.config.base_path}categories/", "#{Ruhoh.config.base_path}categories.html"].each { |url|
           categories_url = url and break if Ruhoh::DB.routes.key?(url)
         }
         Ruhoh::DB.posts['categories'].each do |key, value|
@@ -32,7 +33,7 @@ class Ruhoh
         end
         
         tags_url = nil
-        ['/tags', '/tags.html'].each { |url|
+        ["#{Ruhoh.config.base_path}tags/", "#{Ruhoh.config.base_path}tags.html"].each { |url|
           tags_url = url and break if Ruhoh::DB.routes.key?(url)
         }
         Ruhoh::DB.posts['tags'].each do |key, value|

--- a/lib/ruhoh/parsers/posts.rb
+++ b/lib/ruhoh/parsers/posts.rb
@@ -138,11 +138,11 @@ class Ruhoh
         date = Date.parse(post['date'])
         title = Ruhoh::Urls.to_url_slug(post['title'])
         format = post['permalink'] || Ruhoh.config.posts_permalink  || "/:categories/:year/:month/:day/:title.html"
-        
+
         # Use the literal permalink if it is a non-tokenized string.
         unless format.include?(':')
           url = format.gsub(/^\//, '').split('/').map {|p| CGI::escape(p) }.join('/')
-          return "/#{url}"
+          return "#{Ruhoh.config.base_path}#{url}"
         end  
 
         filename = File.basename(post['id'], File.extname(post['id']))
@@ -162,6 +162,8 @@ class Ruhoh
           result.gsub(/:#{Regexp.escape token.first}/, token.last)
         }.gsub(/\/+/, "/")
 
+        url = url.gsub(/^\//, '') #prep for prepending the base_path
+        url = "#{Ruhoh.config.base_path}#{url}"
         url
       end
     

--- a/lib/ruhoh/parsers/stylesheets.rb
+++ b/lib/ruhoh/parsers/stylesheets.rb
@@ -24,8 +24,9 @@ class Ruhoh
         Ruhoh::DB.theme_config[Ruhoh.names.stylesheets].each do |key, value|
           next if key == Ruhoh.names.widgets # Widgets are handled separately.
           assets[key] = Array(value).map { |v|
+            url = (v =~ /^(http:|https:)?\/\//i) ? v : "#{Ruhoh.urls.theme_stylesheets}/#{v}"
             {
-              "url" => "#{Ruhoh.urls.theme_stylesheets}/#{v}",
+              "url" => url,
               "id" => File.join(Ruhoh.paths.theme_stylesheets, v)
             }
           }

--- a/lib/ruhoh/parsers/stylesheets.rb
+++ b/lib/ruhoh/parsers/stylesheets.rb
@@ -10,19 +10,18 @@ class Ruhoh
       # Generates mappings to all registered stylesheets.
       # Returns Hash with layout names as keys and Array of asset Objects as values
       def self.generate
-        theme_config = self.theme_config
-        assets = self.theme_stylesheets(theme_config)
-        assets[Ruhoh.names.widgets] = self.widget_stylesheets(theme_config)
+        assets = self.theme_stylesheets
+        assets[Ruhoh.names.widgets] = self.widget_stylesheets
         assets
       end
       
       # Create mappings for stylesheets registered to the theme layouts.
       # Themes register stylesheets relative to their layouts.
       # Returns Hash with layout names as keys and Array of asset Objects as values.
-      def self.theme_stylesheets(theme_config)
-        return {} unless theme_config[Ruhoh.names.stylesheets].is_a? Hash
+      def self.theme_stylesheets
+        return {} unless Ruhoh::DB.theme_config[Ruhoh.names.stylesheets].is_a? Hash
         assets = {}
-        theme_config[Ruhoh.names.stylesheets].each do |key, value|
+        Ruhoh::DB.theme_config[Ruhoh.names.stylesheets].each do |key, value|
           next if key == Ruhoh.names.widgets # Widgets are handled separately.
           assets[key] = Array(value).map { |v|
             {
@@ -41,11 +40,11 @@ class Ruhoh
       # Themes may also specify an explicit widget stylesheet to load.
       # 
       # Returns Array of asset objects.
-      def self.widget_stylesheets(theme_config)
+      def self.widget_stylesheets
         assets = []
         Ruhoh::DB.widgets.each_key do |name|
           default_name = "#{name}.css"
-          stylesheet = theme_config[Ruhoh.names.stylesheets][Ruhoh.names.widgets][name] rescue default_name
+          stylesheet = Ruhoh::DB.theme_config[Ruhoh.names.stylesheets][Ruhoh.names.widgets][name] rescue default_name
           stylesheet ||=  default_name
           file = File.join(Ruhoh.paths.theme_widgets, name, Ruhoh.names.stylesheets, stylesheet)
           next unless File.exists?(file)
@@ -58,18 +57,6 @@ class Ruhoh
         assets
       end
       
-      def self.theme_config
-        theme_config = Ruhoh::Utils.parse_yaml_file(Ruhoh.paths.theme_config_data)
-        if theme_config.nil?
-          Ruhoh::Friend.say{ 
-            yellow "WARNING: theme.yml config file not found:"
-            yellow "  #{Ruhoh.paths.theme_config_data}"
-          }
-          return {}
-        end
-        return {} unless theme_config.is_a? Hash
-        theme_config
-      end
     end #Stylesheets
   end #Parsers
 end #Ruhoh

--- a/lib/ruhoh/parsers/theme_config.rb
+++ b/lib/ruhoh/parsers/theme_config.rb
@@ -1,0 +1,21 @@
+class Ruhoh
+  module Parsers
+    module ThemeConfig
+      
+      def self.generate
+        config = Ruhoh::Utils.parse_yaml_file(Ruhoh.paths.theme_config_data)
+        if config.nil?
+          Ruhoh::Friend.say{ 
+            yellow "WARNING: theme.yml config file not found:"
+            yellow "  #{Ruhoh.paths.theme_config_data}"
+          }
+          return {}
+        end
+        return {} unless config.is_a? Hash
+        
+        config
+      end
+      
+    end #ThemeConfig
+  end #Parsers
+end #Ruhoh

--- a/lib/ruhoh/parsers/theme_config.rb
+++ b/lib/ruhoh/parsers/theme_config.rb
@@ -13,6 +13,15 @@ class Ruhoh
         end
         return {} unless config.is_a? Hash
         
+        config["exclude"] = Array(config['exclude']).compact.map do |node| 
+          is_last = node[0] == "*"
+          node = node.chomp("*").reverse.chomp("*").reverse
+          node = Regexp.escape("#{node}")
+          node = is_last ? "#{node}$" : "^#{node}"
+          
+          Regexp.new(node, true)
+        end
+        
         config
       end
       

--- a/lib/ruhoh/paths.rb
+++ b/lib/ruhoh/paths.rb
@@ -32,22 +32,22 @@ class Ruhoh
       :system_widgets
     )
     
-    def self.generate(config, base)
+    def self.generate
       paths                     = Paths.new
-      paths.base                = base
-      paths.config_data         = File.join(base, Ruhoh.names.config_data)
-      paths.pages               = File.join(base, Ruhoh.names.pages)
-      paths.posts               = File.join(base, Ruhoh.names.posts)
-      paths.partials            = File.join(base, Ruhoh.names.partials)
-      paths.media               = File.join(base, Ruhoh.names.media)
-      paths.widgets             = File.join(base, Ruhoh.names.widgets)
-      paths.compiled            = File.join(base, Ruhoh.names.compiled)
-      paths.dashboard_file      = File.join(base, Ruhoh.names.dashboard_file)
-      paths.site_data           = File.join(base, Ruhoh.names.site_data)
-      paths.themes              = File.join(base, Ruhoh.names.themes)
-      paths.plugins             = File.join(base, Ruhoh.names.plugins)
+      paths.base                = Ruhoh.base
+      paths.config_data         = File.join(Ruhoh.base, Ruhoh.names.config_data)
+      paths.pages               = File.join(Ruhoh.base, Ruhoh.names.pages)
+      paths.posts               = File.join(Ruhoh.base, Ruhoh.names.posts)
+      paths.partials            = File.join(Ruhoh.base, Ruhoh.names.partials)
+      paths.media               = File.join(Ruhoh.base, Ruhoh.names.media)
+      paths.widgets             = File.join(Ruhoh.base, Ruhoh.names.widgets)
+      paths.compiled            = File.join(Ruhoh.base, Ruhoh.names.compiled)
+      paths.dashboard_file      = File.join(Ruhoh.base, Ruhoh.names.dashboard_file)
+      paths.site_data           = File.join(Ruhoh.base, Ruhoh.names.site_data)
+      paths.themes              = File.join(Ruhoh.base, Ruhoh.names.themes)
+      paths.plugins             = File.join(Ruhoh.base, Ruhoh.names.plugins)
       
-      paths.theme               = File.join(base, Ruhoh.names.themes, config.theme)
+      paths.theme               = File.join(Ruhoh.base, Ruhoh.names.themes, Ruhoh.config.theme)
       paths.theme_dashboard_file= File.join(paths.theme, Ruhoh.names.dashboard_file)
       paths.theme_config_data   = File.join(paths.theme, Ruhoh.names.theme_config)
       paths.theme_layouts       = File.join(paths.theme, Ruhoh.names.layouts)

--- a/lib/ruhoh/previewer.rb
+++ b/lib/ruhoh/previewer.rb
@@ -14,7 +14,8 @@ class Ruhoh
 
     def call(env)
       return favicon if env['PATH_INFO'] == '/favicon.ico'
-      return admin if [Ruhoh.urls.dashboard, "#{Ruhoh.urls.dashboard}/"].include?(env['PATH_INFO'])
+      env['PATH_INFO'] += "/" unless (env['PATH_INFO'] =~ /\.\w+$/ || env['PATH_INFO'][-1] == "/")
+      return admin if env['PATH_INFO'] == "#{Ruhoh.urls.dashboard}/"
       
       id = Ruhoh::DB.routes[env['PATH_INFO']]
       raise "Page id not found for url: #{env['PATH_INFO']}" unless id

--- a/lib/ruhoh/program.rb
+++ b/lib/ruhoh/program.rb
@@ -18,7 +18,12 @@ class Ruhoh
       
       Ruhoh.setup
       Ruhoh.config.env = opts[:env]
+      Ruhoh.setup_paths
+      Ruhoh.setup_urls
+      Ruhoh.setup_plugins unless opts[:enable_plugins] == false
+      
       Ruhoh::DB.update_all
+      
       Ruhoh::Watch.start if opts[:watch]
       Rack::Builder.new {
         use Rack::Lint
@@ -51,6 +56,10 @@ class Ruhoh
     def self.compile(target)
       Ruhoh.setup
       Ruhoh.config.env = 'production'
+      Ruhoh.setup_paths
+      Ruhoh.setup_urls
+      Ruhoh.setup_plugins
+      
       Ruhoh::DB.update_all
       Ruhoh::Compiler.compile(target)
     end

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -29,7 +29,7 @@ class Ruhoh
     end
 
     def self.to_url(*args)
-      args.unshift(nil).join('/')
+      Ruhoh.config.base_path + args.join('/')
     end
     
     def self.to_url_slug(title)

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -14,20 +14,20 @@ class Ruhoh
       :theme_widgets
     )
 
-    def self.generate(config)
+    def self.generate
       urls                      = Urls.new
       urls.media                = self.to_url(Ruhoh.names.assets, Ruhoh.names.media)
       urls.widgets              = self.to_url(Ruhoh.names.assets, Ruhoh.names.widgets)
       urls.dashboard            = self.to_url(Ruhoh.names.dashboard_file.split('.')[0])
 
-      urls.theme                = self.to_url(Ruhoh.names.assets, config.theme)
-      urls.theme_media          = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.media)
-      urls.theme_javascripts    = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.javascripts)
-      urls.theme_stylesheets    = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.stylesheets)
-      urls.theme_widgets        = self.to_url(Ruhoh.names.assets, config.theme, Ruhoh.names.widgets)
+      urls.theme                = self.to_url(Ruhoh.names.assets, Ruhoh.config.theme)
+      urls.theme_media          = self.to_url(Ruhoh.names.assets, Ruhoh.config.theme, Ruhoh.names.media)
+      urls.theme_javascripts    = self.to_url(Ruhoh.names.assets, Ruhoh.config.theme, Ruhoh.names.javascripts)
+      urls.theme_stylesheets    = self.to_url(Ruhoh.names.assets, Ruhoh.config.theme, Ruhoh.names.stylesheets)
+      urls.theme_widgets        = self.to_url(Ruhoh.names.assets, Ruhoh.config.theme, Ruhoh.names.widgets)
       urls
     end
-    
+
     def self.to_url(*args)
       args.unshift(nil).join('/')
     end


### PR DESCRIPTION
Important updates for your consideration:
- **Ruhoh.setup**
  has now been pieced-out into more atomic method calls. 
  This allows us to add in custom logic before, after, around each individual routine as well as override configuration variables if we so desire.
-  **base_path support**
  Ruhoh now supports a customizable base_path setting that prepends itself, globally, to all links generated by ruhoh. It should do so in an abstracted way so toggling off/on is easy and cleanly affects all urls. This allows you to serve your blog from a custom sub-directory e.g. `/my-blog/`
- **All theme assets are now ported to production unless explicitly excluded**
  Previously only theme assets explicitly registered to the stylesheets/javascripts hash were included into the production blog. This caused necessary files such as images, fonts, and imported css from not being included -- pretty annoying bug. Now every file within a theme is transfered over. However themes.yml provides an `exclude` hash that allows the user to configure assets to be excluded from the compilation.

Full documentation and usage guides to follow. Developers are encouraged to inspect the source provided in this pull-request
