### PR TITLE
Allow the user to specify a custom scaffold url and support using mercurial(hg).

### DIFF
--- a/bin/ruhoh
+++ b/bin/ruhoh
@@ -8,7 +8,7 @@ require 'ruhoh/client/client'
 
 require 'optparse'
 
-Options = Struct.new(:title, :date, :ext, :verbose)
+Options = Struct.new(:title, :date, :ext, :hg, :verbose)
 options = Options.new
 
 opt_parser = OptionParser.new do |opts|

--- a/bin/ruhoh
+++ b/bin/ruhoh
@@ -18,6 +18,10 @@ opt_parser = OptionParser.new do |opts|
     options.ext = ext
   end
   
+  opts.on("--hg", "Use mercurial (hg) instead of git for source control.") do
+    options.hg = true
+  end
+
   opts.on("-v", "--[no-]verbose", "Run verbosely. For pages, shows extra title, url meta-data.") do |v|
     options.verbose = v
   end

--- a/lib/ruhoh/client/client.rb
+++ b/lib/ruhoh/client/client.rb
@@ -140,6 +140,8 @@ class Ruhoh
     # Public: Create a new blog at the directory provided.
     def blog
       name = @args[1]
+      scaffold = @args.length > 2 ? @args[2] : BlogScaffold
+      useHg = @options.hg
       Ruhoh::Friend.say { 
         red "Please specify a directory path." 
         plain "  ex: ruhoh new the-blogist"
@@ -156,9 +158,16 @@ class Ruhoh
       
       Ruhoh::Friend.say { 
         plain "Trying this command:"
-        cyan "  git clone #{BlogScaffold} #{target_directory}"
 
-        if system('git', 'clone', BlogScaffold, target_directory)
+        if useHg
+          cyan "  hg clone #{scaffold} #{target_directory}"
+          success = system('hg', 'clone', scaffold, target_directory)
+        else
+          cyan "  git clone #{BlogScaffold} #{target_directory}"
+          success = system('git', 'clone', BlogScaffold, target_directory)
+        end
+
+        if success
           green "Success! Now do..."
           cyan "  cd #{target_directory}"
           cyan "  rackup -p9292"

--- a/lib/ruhoh/client/client.rb
+++ b/lib/ruhoh/client/client.rb
@@ -4,7 +4,7 @@ class Ruhoh
   class Client
     
     Paths = Struct.new(:page_template, :draft_template, :post_template, :layout_template, :theme_template)
-    BlogScaffold = 'git://github.com/ruhoh/blog.git'
+    DefaultBlogScaffold = 'git://github.com/ruhoh/blog.git'
     
     def initialize(data)
       @iterator = 0
@@ -140,7 +140,7 @@ class Ruhoh
     # Public: Create a new blog at the directory provided.
     def blog
       name = @args[1]
-      scaffold = @args.length > 2 ? @args[2] : BlogScaffold
+      scaffold = @args.length > 2 ? @args[2] : DefaultBlogScaffold
       useHg = @options.hg
       Ruhoh::Friend.say { 
         red "Please specify a directory path." 
@@ -163,8 +163,8 @@ class Ruhoh
           cyan "  hg clone #{scaffold} #{target_directory}"
           success = system('hg', 'clone', scaffold, target_directory)
         else
-          cyan "  git clone #{BlogScaffold} #{target_directory}"
-          success = system('git', 'clone', BlogScaffold, target_directory)
+          cyan "  git clone #{scaffold} #{target_directory}"
+          success = system('git', 'clone', scaffold, target_directory)
         end
 
         if success


### PR DESCRIPTION
...

The user can specify the scaffold url on the command line like so...
    ruhoh new <blog name> <scaffold url>

If the user wants to use mercurial (hg) instead of git, they can simply add the
option `--hg` now.  The command will look like this...
    ruhoh --hg new <blog name>

The default scaffold is a git repository, so a mercurial user (like myself) will
either have to install the hg-git plugin for mercurial, or specify a custom
scaffold that is kept in a mercurial repository.
