### PR TITLE
Only use post content in the RSS description field.

### DIFF
--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -26,7 +26,7 @@ class Ruhoh
                  xml.title_ post['title']
                  xml.link "#{Ruhoh::DB.site['config']['production_url']}#{post['url']}"
                  xml.pubDate_ post['date']
-                 xml.description_ (post['description'] ? post['description'] : page.render)
+                 xml.description_ (post['description'] ? post['description'] : page.render_rss)
                }
              end
            }

--- a/lib/ruhoh/compilers/rss.rb
+++ b/lib/ruhoh/compilers/rss.rb
@@ -26,7 +26,7 @@ class Ruhoh
                  xml.title_ post['title']
                  xml.link "#{Ruhoh::DB.site['config']['production_url']}#{post['url']}"
                  xml.pubDate_ post['date']
-                 xml.description_ (post['description'] ? post['description'] : page.render_rss)
+                 xml.description_ (post['description'] ? post['description'] : page.render_content)
                }
              end
            }

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -28,6 +28,11 @@ class Ruhoh
       @templater.render(self.expand_layouts, self.payload)
     end
     
+    def render_rss
+      self.ensure_id
+      @templater.render(self.expand_layouts, self.payload)
+    end
+    
     def process_layouts
       self.ensure_id
       if @data['layout']

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -28,9 +28,9 @@ class Ruhoh
       @templater.render(self.expand_layouts, self.payload)
     end
     
-    def render_rss
+    def render_content
       self.ensure_id
-      @templater.render(self.expand_layouts, self.payload)
+      @templater.render('{{{content}}}', self.payload)
     end
     
     def process_layouts


### PR DESCRIPTION
This patch improves the RSS feed.  Previously the description field was
populated with the entire web page including the header, footer, javascript,
css, etc.  Now the description field is only populated with html rendered from
a post.

I tested this with Google Reader and the resulting output is much nicer.
