### PR TITLE
Fix links not properly rendering in the summary.

### DIFF
--- a/lib/ruhoh/templaters/base_helpers.rb
+++ b/lib/ruhoh/templaters/base_helpers.rb
@@ -31,10 +31,20 @@ class Ruhoh
             line_count += 1
           end
         end
-        
-        content = content.lines.to_a[0, line_breakpoint].join
-        content = self.render(content)
-        Ruhoh::Converter.convert(content, id)
+
+        summary = content.lines.to_a[0, line_breakpoint].join
+
+        # The summary may be missing some key items needed to render properly.
+        # So search the rest of the content and add it to the summary.
+        content.lines.with_index(line_breakpoint) do |line, i|
+          # Add lines containing destination urls.
+          if line =~ /^\[[^\]]+\]:/
+            summary << "\n#{line}"
+          end
+        end
+
+        summary = self.render(summary)
+        Ruhoh::Converter.convert(summary, id)
       end
       
       def pages


### PR DESCRIPTION
This change will search the rest of the content of your post and add any link
destinations to your summary before it gets rendered.  This is especially useful
for people who like to list their link destinations at the bottom of a page or
section, like so...

```
[link1]: http://asdf.com/
[link2]: http://google.com/
```

...and so forth.  Originally, link destinations in this format would be cut off
from the summary if they're past line 30 (by default), so any links using these
destinations in the summary weren't getting rendered properly.
