### PR TITLE
Fix for trailing slashes issue

### DIFF
--- a/lib/ruhoh/config.rb
+++ b/lib/ruhoh/config.rb
@@ -11,7 +11,8 @@ class Ruhoh
       :posts_permalink,
       :rss_limit,
       :theme,
-      :base_path
+      :base_path,
+      :urls_trailing_slashes
     )
 
     def self.generate
@@ -26,10 +27,10 @@ class Ruhoh
         Ruhoh.log.error("Theme not specified in #{Ruhoh.names.config_data}")
         return false
       end
-      
+
       config = Config.new
       config.theme = theme
-      
+
       config.env = site_config['env'] || nil
 
       config.base_path = '/'
@@ -37,7 +38,7 @@ class Ruhoh
         config.base_path = site_config['base_path'].to_s
         config.base_path += "/" unless config.base_path[-1] == '/'
       end
-      
+
       config.rss_limit = site_config['rss']['limit'] rescue nil
       config.rss_limit = 20 if config.rss_limit.nil?
 
@@ -48,14 +49,17 @@ class Ruhoh
       excluded_posts = site_config['posts']['exclude'] rescue nil
       config.posts_exclude = Array(excluded_posts)
       config.posts_exclude = config.posts_exclude.map {|node| Regexp.new(node) }
-      
+
       config.pages_permalink = site_config['pages']['permalink'] rescue nil
       config.pages_layout = site_config['pages']['layout'] rescue nil
       config.pages_layout = 'page' if config.pages_layout.nil?
       excluded_pages = site_config['pages']['exclude'] rescue nil
       config.pages_exclude = Array(excluded_pages)
       config.pages_exclude = config.pages_exclude.map {|node| Regexp.new(node) }
-      
+
+      config.urls_trailing_slashes = site_config['urls']['trailing_slashes'] rescue nil
+      config.urls_trailing_slashes ||= false
+
       config
     end
   end #Config

--- a/lib/ruhoh/page.rb
+++ b/lib/ruhoh/page.rb
@@ -90,8 +90,7 @@ class Ruhoh
     def compiled_path
       self.ensure_id
       path = CGI.unescape(@data['url']).gsub(/^\//, '') #strip leading slash.
-      path = "index.html" if path.empty?
-      path += '/index.html' unless path =~ /\.\w+$/
+      path += 'index.html' if path.end_with?('/') or path.empty?
       path
     end
     

--- a/lib/ruhoh/urls.rb
+++ b/lib/ruhoh/urls.rb
@@ -29,11 +29,18 @@ class Ruhoh
     end
 
     # Ruhoh.config.base_path is assumed to be well-formed.
-    # Always remove trailing slash.
+    # Always remove trailing slash if urls_trailing_slashes == false.
     # Returns String - normalized url with prepended base_path
     def self.to_url(*args)
-      url = args.join('/').chomp('/').reverse.chomp('/').reverse
-      url = Ruhoh.config.base_path + url
+      url= args.join('/')
+      url.slice!(0) if url.start_with?('/')
+      if Ruhoh.config.urls_trailing_slashes == true
+        url += '/' unless url.end_with?('/') or url.end_with?('.html')
+      else
+        url.chomp!('/')
+      end
+      url= (Ruhoh.config.base_path + url).gsub('//', '/')
+
     end
     
     def self.to_url_slug(title)


### PR DESCRIPTION
Adds a toggle ability to have a trailing slash in all URLs.

This solves an issue when Ruhoh-generated sites are served via Apache. Ruhoh's lack of trailing slashes causes Apache to generate redirects by default to force a valid URL. This creates a lot of redirects in normal use, and also breaks category and tag links because Apache's redirects do not keep the hash values.

For example, Ruhoh might generate the URL `http://example.com/tags#tag-ref`, which Apache will redirect to `http://example.com/tags/`. However, on servers which aren't encumbered by Apache's behavior, the convention of omitting the trailing slash is preferable. For this reason, I've chosen to make this behavior configurable instead of a single "one size fits all" solution.

This also reduces the number of extraneous redirects by approximately 100% while running on my site.

I don't necessarily think this is the best way of implementing this solution. I'm interested to see what suggestions or corrections you may have to offer before this pull request is merge-able.

Thanks!
