### PR TITLE
Fix for with_index call on Array

### DIFF
--- a/lib/ruhoh/resources/_page/model_view.rb
+++ b/lib/ruhoh/resources/_page/model_view.rb
@@ -64,7 +64,7 @@ module Ruhoh::Resources::Page
 
       # The summary may be missing some key items needed to render properly.
       # So search the rest of the content and add it to the summary.
-      content.lines.with_index(line_breakpoint) do |line, i|
+      content.lines.to_enum.with_index(line_breakpoint) do |line, i|
         # Add lines containing destination urls.
         if line =~ /^\[[^\]]+\]:/
           summary << "\n#{line}"


### PR DESCRIPTION
I am using ruby 2.0.0p0 (2013-02-24 revision 39474).

ruhoh breaks when rendering summary of a post. Example error:
lib/ruhoh/resources/_page/model_view.rb:67:in `summary': undefined method`with_index' for ["Hi\n", "How are you?"]:Array (NoMethodError)

Perhaps this does not occur on Ruby 1.9.2+ However, in Ruby 2.0, there have been some changes with respect to return types being Array or Enumerator. http://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/

This could have caused this defect. Calling to_enum before using with_index solves the issue. This should also work when the object is already an enumerator.
