### PR TITLE
Breadcrumbs for is_active_page

### DIFF
--- a/lib/ruhoh/resources/_page/model_view.rb
+++ b/lib/ruhoh/resources/_page/model_view.rb
@@ -33,7 +33,8 @@ module Ruhoh::Resources::Page
     end
     
     def is_active_page
-      id == master.page_data['id']
+      breadcrumbs = (master.page_data['breadcrumbs'] || []) + [ master.page_data['id'] ]
+      breadcrumbs.include?(id)
     end
     
     # Truncate the page content relative to a line_count limit.

--- a/spec/lib/ruhoh/resources/_page/model_view_spec.rb
+++ b/spec/lib/ruhoh/resources/_page/model_view_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Ruhoh::Resources::Page
+  describe ModelView do
+    describe "is_active_page" do
+      before(:each) do
+        @index_page_view = ModelView.new(nil, {:id => 'index.html'})
+      end
+
+      it "should be true if it is current page" do
+        @index_page_view.master = master_with_page_data('id' => 'index.html')
+        @index_page_view.is_active_page.should be_true
+      end
+
+      it "should be false if it is not current page" do
+        @index_page_view.master = master_with_page_data('id' => 'some-post.html')
+        @index_page_view.is_active_page.should be_false
+      end
+
+      it "should be true if it is not current page but is in breadcrumbs" do
+        @index_page_view.master = master_with_page_data('id' => 'some-post.html', 'breadcrumbs' => ['index.html', 'blog.html'])
+        @index_page_view.is_active_page.should be_true
+      end
+
+    end
+
+    def master_with_page_data(page_data)
+      master = Ruhoh::Views::MasterView.new(nil, nil)
+      master.page_data = page_data
+      master
+    end
+  end
+end
+

--- a/system/widgets/analytics/layouts/google.html
+++ b/system/widgets/analytics/layouts/google.html
@@ -1,5 +1,5 @@
 <script>
-  var _gaq=[['_setAccount','{{ config.google.tracking_id }}'],['_trackPageview']];
+  var _gaq=[['_setAccount','{{ config.google.tracking_id }}']{{# config.google.domain_name }},['_setDomainName', '{{ . }}']{{/ config.google.domain_name }},['_trackPageview']];
   (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
   g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
   s.parentNode.insertBefore(g,s)}(document,'script'));


### PR DESCRIPTION
I had the following use case:

Some pages have a hierarchy structure. Not all of such pages will be in top navigation bar. I wanted the appropriate parent page link to appear "active" if any descendent is the current page.

Eg:
Blog (index.html) -> Some Blog Post (some-blog-post.md)
In above case, I would like "Blog" nav link to appear active when viewing "Some Blog Post".

I have introduced "breadcrumbs" YAML metadata to enable above behavior. 
Eg:
some-blog-post.md
-----------
breadcrumbs: ['index.html']
-----------

Please merge if appropriate for everyone.

I like to TDD. Noticed that a LOT of specs were deleted on 5 Jan 2013. Not sure of your unit-test-related plans going forward, so I have committed my specs in a separate commit just in case you don't want the specs. Please let me know for future pull requests.

Thanks.
