### PR TITLE
Constrain directory_watcher to working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 gemspec
 
 gem 'rack', "~> 1.4"
-gem 'directory_watcher', "~> 1.4"
+gem 'directory_watcher', "~> 1.4.1"
 gem 'psych', "~> 1.3", :platforms => [:ruby_18, :mingw_18]
 gem 'redcarpet', "~> 2.1"
 gem 'nokogiri', "~> 1.5"

--- a/ruhoh.gemspec
+++ b/ruhoh.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # dependencies defined in Gemfile
   s.add_dependency 'rack', "~> 1.4"
   s.add_dependency 'mustache', "~> 0.99"
-  s.add_dependency 'directory_watcher', "~> 1.4"
+  s.add_dependency 'directory_watcher', "~> 1.4.1"
   s.add_dependency 'redcarpet', "~> 2.1"
   s.add_dependency 'nokogiri', "~> 1.5"
   


### PR DESCRIPTION
If you run bundle update, the directory_watcher gem gets updated to version 1.5.1.  This is evidently incompatible with ruhoh because it throws an exception whenever a file changes, instead of reparsing.

This is on Windows with ruhoh 2.0.alpha.3.

This commit just locks the directory_watcher version to any 1.4.1+ release in the Gemfile and gemspec.
