### PR TITLE
Give widgets access to current page data

### DIFF
--- a/lib/ruhoh/resources/widgets/collection_view.rb
+++ b/lib/ruhoh/resources/widgets/collection_view.rb
@@ -10,7 +10,7 @@ module Ruhoh::Resources::Widgets
       return '' unless model
 
       view = ruhoh.master_view({})
-
+            
       # merge the config.yml data into the inline layout data.
       # Note this is reversing the normal hierarchy 
       # in that inline should always override config level.
@@ -18,7 +18,8 @@ module Ruhoh::Resources::Widgets
       # and meant to be overridden by user specific data.
       view.render(model.content, {
         "this_config" => model.data.merge(widget_config),
-        "this_path" => ruhoh.to_url(url_endpoint, name)
+        "this_path" => ruhoh.to_url(url_endpoint, name),
+        "this_page" => master.page_data,
       })
     end
 


### PR DESCRIPTION
One of my widgets needed the page URL, so I added page data to the widget payload in the "this_page" variable.
