### PR TITLE
Add folder config error handling

### DIFF
--- a/lib/ruhoh/base/model.rb
+++ b/lib/ruhoh/base/model.rb
@@ -99,7 +99,12 @@ module Ruhoh::Base
 
       page = File.open(@pointer['realpath'], 'r:UTF-8') {|f| f.read }
 
-      front_matter = page.match(FMregex)
+      begin
+        front_matter = page.match(FMregex)
+      rescue => e
+        raise "Error trying to read meta-data from #{@pointer['realpath']}.  Check your folder configuration."
+      end
+        
       data = front_matter ?
         (YAML.load(front_matter[0].gsub(/---\n/, "")) || {}) :
         {}

--- a/lib/ruhoh/base/model.rb
+++ b/lib/ruhoh/base/model.rb
@@ -102,7 +102,8 @@ module Ruhoh::Base
       begin
         front_matter = page.match(FMregex)
       rescue => e
-        raise "Error trying to read meta-data from #{@pointer['realpath']}.  Check your folder configuration."
+        raise "Error trying to read meta-data from #{@pointer['realpath']}." +
+        " Check your folder configuration.  Error details: #{e}"
       end
         
       data = front_matter ?


### PR DESCRIPTION
Added a more meaningful error message when it can't parse the file metadata.   (Because I put in a theme folder and forgot to add it to the site config, and it took me awhile to figure out what I had done wrong to get an obscure "UTF8 parse" error.)
