### PR TITLE
Allow post titles to have dates appended automatically

### DIFF
--- a/lib/ruhoh/resources/pages/client.rb
+++ b/lib/ruhoh/resources/pages/client.rb
@@ -67,9 +67,9 @@ module Ruhoh::Resources::Pages
 
     def create(opts={})
       ruhoh = @ruhoh
-
       begin
         file = @args[2] || "untitled"
+        file = file.gsub('{{DATE}}', Time.now.strftime('%Y-%m-%d'))
         ext = File.extname(file).to_s
         ext  = ext.empty? ? @collection.config["ext"] : ext
 


### PR DESCRIPTION
Can use the {{DATE}} keyword in a new post:

```
ruhoh post "{{DATE}} New post"
```
