### PR TITLE
Require 'forwardable' in sprockets plugin.

### DIFF
--- a/system/plugins/sprockets/javascripts/previewer.rb
+++ b/system/plugins/sprockets/javascripts/previewer.rb
@@ -1,4 +1,5 @@
 require 'sprockets'
+require 'forwardable'
 module Ruhoh::Resources::Javascripts
   class Previewer
     extend Forwardable

--- a/system/plugins/sprockets/stylesheets/previewer.rb
+++ b/system/plugins/sprockets/stylesheets/previewer.rb
@@ -1,4 +1,5 @@
 require 'sprockets'
+require 'forwardable'
 module Ruhoh::Resources::Stylesheets
   class Previewer
     extend Forwardable


### PR DESCRIPTION
This fixes the following error in ruby 2.0.0:

```
uninitialized constant Ruhoh::Resources::Stylesheets::Previewer::Forwardable (NameError)
```
