### PR TITLE
Reorganize/fix the Sprockets Plugin

### DIFF
--- a/system/plugins/sprockets/compiler.rb
+++ b/system/plugins/sprockets/compiler.rb
@@ -1,0 +1,38 @@
+require 'sprockets'
+
+module Ruhoh::SprocketsPlugin
+  module Compiler
+    extend Ruhoh::Base::CompilableAsset
+    def run
+      env = Sprockets::Environment.new
+      env.logger = Logger.new(STDOUT)
+      env.logger.level = Logger::WARN
+
+      collection = @collection
+
+      unless collection.paths?
+        Ruhoh::Friend.say { yellow "#{collection.resource_name.capitalize}: directory not found - skipping." }
+        return
+      end
+
+      Ruhoh::Friend.say { cyan "#{collection.resource_name.capitalize}: (using sprockets)" }
+
+      collection.paths.reverse.each do |path|
+        env.append_path(path)
+      end
+
+      compiled_path = Ruhoh::Utils.url_to_path(@ruhoh.to_url(collection.url_endpoint), @ruhoh.paths.compiled)
+      FileUtils.mkdir_p compiled_path
+
+      manifest = Sprockets::Manifest.new(env, compiled_path)
+      assets = collection.files.values.map{ |p|
+        Ruhoh::Friend.say { green "  > #{p['id']}" }
+        p["id"]
+      }
+      manifest.compile(assets)
+
+      # Update the paths to the digest format:
+      @collection._cache.merge!(manifest.assets)
+    end
+  end
+end

--- a/system/plugins/sprockets/javascripts/compiler.rb
+++ b/system/plugins/sprockets/javascripts/compiler.rb
@@ -1,25 +1,3 @@
-require 'sprockets'
-module Ruhoh::Resources::Javascripts
-  class Compiler
-    include Ruhoh::Base::Compilable
-
-    def run
-      Ruhoh::Friend.say { cyan "Javascripts: (using sprockets)" }
-      env = Sprockets::Environment.new
-      env.logger = Logger.new(STDOUT)
-      @collection.paths.reverse.each do |h|
-        env.append_path(File.join(h["path"], @collection.resource_name))
-      end
-
-      compiled_path = Ruhoh::Utils.url_to_path(@collection.url_endpoint, @ruhoh.paths.compiled)
-      FileUtils.mkdir_p compiled_path
-
-      manifest = Sprockets::Manifest.new(env, compiled_path)
-      assets = @collection.files.values.map{ |p| p["id"] }
-      manifest.compile(assets)
-
-      # Update the stylesheet paths to the digest format:
-      @collection._cache.merge!(manifest.assets)
-    end
-  end
+class Ruhoh::Resources::Javascripts::Compiler
+  include Ruhoh::SprocketsPlugin::Compiler
 end

--- a/system/plugins/sprockets/javascripts/previewer.rb
+++ b/system/plugins/sprockets/javascripts/previewer.rb
@@ -1,18 +1,8 @@
-require 'sprockets'
-require 'forwardable'
 module Ruhoh::Resources::Javascripts
   class Previewer
-    extend Forwardable
-
-    def_instance_delegator :@environment, :call
-
+    include Ruhoh::SprocketsPlugin::Previewer
     def initialize(ruhoh)
-      environment = Sprockets::Environment.new
-      collection = ruhoh.collection('javascripts')
-      collection.paths.reverse.each do |path|
-        environment.append_path(path)
-      end
-      @environment = environment
+      super(ruhoh.collection('javascripts'))
     end
   end
 end

--- a/system/plugins/sprockets/previewer.rb
+++ b/system/plugins/sprockets/previewer.rb
@@ -1,0 +1,17 @@
+require 'sprockets'
+require 'forwardable'
+
+module Ruhoh::SprocketsPlugin
+  module Previewer
+      extend Forwardable
+      def_instance_delegator :@environment, :call
+
+      def initialize(collection)
+        environment = Sprockets::Environment.new
+        collection.paths.reverse.each do |path|
+          environment.append_path(path)
+        end
+        @environment = environment
+      end
+  end
+end

--- a/system/plugins/sprockets/stylesheets/compiler.rb
+++ b/system/plugins/sprockets/stylesheets/compiler.rb
@@ -1,26 +1,3 @@
-require 'sprockets'
-module Ruhoh::Resources::Stylesheets
-  class Compiler
-    include Ruhoh::Base::Compilable
-
-    def run
-      Ruhoh::Friend.say { cyan "Stylesheets: (using sprockets)" }
-      env = Sprockets::Environment.new
-      env.logger = Logger.new(STDOUT)
-      @collection.paths.reverse.each do |h|
-        env.append_path(File.join(h["path"], @collection.resource_name))
-      end
-      
-      compiled_path = Ruhoh::Utils.url_to_path(@collection.url_endpoint, @ruhoh.paths.compiled)
-      FileUtils.mkdir_p compiled_path
-
-      manifest = Sprockets::Manifest.new(env, compiled_path)
-      assets = @collection.files.values.map{ |p| p["id"] }
-      puts assets.inspect
-      manifest.compile(assets)
-
-      # Update the stylesheet paths to the digest format:
-      @collection._cache.merge!(manifest.assets)
-    end
-  end
+class Ruhoh::Resources::Stylesheets::Compiler
+  include Ruhoh::SprocketsPlugin::Compiler
 end

--- a/system/plugins/sprockets/stylesheets/previewer.rb
+++ b/system/plugins/sprockets/stylesheets/previewer.rb
@@ -1,18 +1,8 @@
-require 'sprockets'
-require 'forwardable'
 module Ruhoh::Resources::Stylesheets
   class Previewer
-    extend Forwardable
-
-    def_instance_delegator :@environment, :call
-
+    include Ruhoh::SprocketsPlugin::Previewer
     def initialize(ruhoh)
-      environment = Sprockets::Environment.new
-      collection = ruhoh.collection('stylesheets')
-      collection.paths.reverse.each do |path|
-        environment.append_path(path)
-      end
-      @environment = environment
+      super(ruhoh.collection('stylesheets'))
     end
   end
 end


### PR DESCRIPTION
The compile function of the sprockets plugin was out of sync with the
rest of ruhoh and no longer worked. In the process of fixing it, I ended
up reogranizing the previewer and compiler code to match the layout of
Ruhoh's built-in compiler code as much as possible.
