### PR TITLE
Better summary generation

### DIFF
--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -97,7 +97,8 @@ module Ruhoh::Base
     # - If summary_stop_at_header is true, stop before any headers.
     def summary
       # Parse the document
-      content_doc = Nokogiri::HTML.fragment(content)
+      full_content = @ruhoh.master_view(@model.pointer).render_content
+      content_doc = Nokogiri::HTML.fragment(full_content)
 
       # Return a summary element if specified
       summary_el = content_doc.at_css('.summary')

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -118,15 +118,15 @@ module Ruhoh::Base
       headings = Nokogiri::HTML::ElementDescription::HEADING + ["header", "hgroup"]
 
       content_doc.children.each do |node|
-        if stop_at_header and headings.include? node.name then
+        if stop_at_header && headings.include? node.name
           summary_doc["class"] += " ellipsis"
           break
         end
 
-        if line_limit > 0 and summary_doc.content.lines.length > line_limit then
+        if line_limit > 0 && summary_doc.content.lines.to_a.length > line_limit
           # Skip through leftover whitespace. Without this check, the summary
           # can be marked as ellipsis even if it isn't.
-          unless node.text? and node.text.strip.empty? then
+          unless node.text? && node.text.strip.empty?
             summary_doc["class"] += " ellipsis"
             break
           else

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -118,7 +118,7 @@ module Ruhoh::Base
       headings = Nokogiri::HTML::ElementDescription::HEADING + ["header", "hgroup"]
 
       content_doc.children.each do |node|
-        if stop_at_header && headings.include? node.name
+        if stop_at_header && headings.include?(node.name)
           summary_doc["class"] += " ellipsis"
           break
         end

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -113,7 +113,7 @@ module Ruhoh::Base
       stop_at_header = @model.collection.config['summary_stop_at_header'] if stop_at_header.nil?
 
       # Create the summary element.
-      summary_doc = Nokogiri::XML::Node.new("span", Nokogiri::HTML::Document.new)
+      summary_doc = Nokogiri::XML::Node.new("div", Nokogiri::HTML::Document.new)
 
       # Tracks whether or not non-header content has been included.
       content_included = false

--- a/lib/ruhoh/resources/pages/collection.rb
+++ b/lib/ruhoh/resources/pages/collection.rb
@@ -42,6 +42,7 @@ module Ruhoh::Resources::Pages
       hash['permalink'] ||= "/:path/:filename"
       hash['summary_lines'] ||= 20
       hash['summary_lines'] = hash['summary_lines'].to_i
+      hash['summary_stop_at_header'] ||= false
       hash['latest'] ||= 2
       hash['latest'] = hash['latest'].to_i
       hash['ext'] ||= ".md"


### PR DESCRIPTION
Yet another pull request (sorry). Overall, this makes the summary generation smarter.

This patch improves the summary generation by:
- Ensuring that elements are not truncated.
- Working properly with any content format (not just markdown).
- Allowing the user to manually indicate the summary (by wrapping it in an element with the `summary` class).
- Allowing the user to truncate the summary at headers (by setting `summary_stop_at_header`) .

The new summary generation function works as follows:
- If a summary element (`<tag class="summary">...</tag>`) is specified
  in the content, return it.
- If the `summary_lines` option is greater than 0, truncate after the first complete element where the number of summary lines is greater than `summary_lines`.
- If the `summary_stop_at_header` option (new) is true, stop before the first header ~~that
  is after some non-empty content. That is, include any headers at the
  top of a post but not subsequent ones~~. (no use case)
- Finally, if any non-whitespace text was truncated, the `ellipsis`
  class is added to the summary element.

It also lets the user override the summary settings on a per-post basis.

Questions(ish):
1. Should the summary options be broken into their own section?
2. Should there be options for changing the summary and ellipsis class names? Should there be an option for changing the summary wrapper tag (to something other than `div`)?
3. ~~Should there be a way to manually set the summary content in the yaml header?~~ not needed
4. Code quality?
5. Overkill?
6. Should an ellipsis element be appended instead of adding an ellipsis class? Even with the class, users can use `.summary.ellipsis:after` to append content.
