### PR TITLE
Update google analytics tracking script to latest recommended

### DIFF
--- a/system/widgets/analytics/google.html
+++ b/system/widgets/analytics/google.html
@@ -2,9 +2,17 @@
 tracking_id : 'UA-123-12'
 ---
 
-<script>
-  var _gaq=[['_setAccount','{{ this_config.tracking_id }}'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-  g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-  s.parentNode.insertBefore(g,s)}(document,'script'));
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', '{{ this_config.tracking_id }}']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
 </script>
+


### PR DESCRIPTION
The current version of the google analytics script used by the widget isn't in sync with Google's latest recommended.  This new version, while only functionally only different by the fact that it loads asynchronously (a good thing for performance), also visually matches Google's current so you can tell that you're using the latest.
