### PR TITLE
Add trailing slash to urls in dev and production

### DIFF
--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -147,7 +147,6 @@ class Ruhoh
   def to_url(*args)
     url = base_path + args.join('/')
     url = url.gsub(/\/{2,}/, '/')
-    (url == "/") ? url : url.chomp('/')
   end
 
   def relative_path(filename)
@@ -256,3 +255,4 @@ class Ruhoh
     Collections.get_module_namespace_for(resource).const_get(:ModelView)
   end
 end
+

--- a/lib/ruhoh/base/model.rb
+++ b/lib/ruhoh/base/model.rb
@@ -219,7 +219,7 @@ module Ruhoh::Base
       end
 
       unless (page_data['permalink_ext'] || collection.config['permalink_ext'])
-        url = url.gsub(/index.html$/, '').gsub(/\.html$/, '')
+        url = url.gsub(/index.html$/, '').gsub(/\.html$/, '/')
       end
 
       url = '/' if url.empty?

--- a/lib/ruhoh/resources/pages/previewer.rb
+++ b/lib/ruhoh/resources/pages/previewer.rb
@@ -9,9 +9,6 @@ module Ruhoh::Resources::Pages
     def call(env)
       return favicon if env['PATH_INFO'] == '/favicon.ico'
 
-      # Always remove trailing slash if sent unless it's the root page.
-      env['PATH_INFO'].chomp!("/") unless env['PATH_INFO'] == "/"
-
       pointer = @ruhoh.routes.find(env['PATH_INFO'])
       Ruhoh::Friend.say {
         plain "- previewing page:"
@@ -21,7 +18,7 @@ module Ruhoh::Resources::Pages
       view = pointer ? @ruhoh.master_view(pointer) : paginator_view(env)
 
       if view
-        [200, {'Content-Type' => 'text/html'}, [view.render_full]]
+        [200, {'Content-Type' => 'text/html; charset=utf-8'}, [view.render_full]]
       else
         message = "No generated page URL matches '#{ env['PATH_INFO'] }'" +
           " using file pointer: '#{ pointer.inspect }'."


### PR DESCRIPTION
This isn't so much a real pull request as it is a proof of concept.

In production I've had to add trailing slashes to all pretty urls so that when hosting on S3 I don't get redirects on every page (from non-slashed to slashed), thereby slowing down the site unnecessarily.

Since running in development runs off the same code, and I wasn't tricky enough to build in a configuration option, I had to make development accept the trailing slashes as well.  Here's the code which does both in this commit.

My suggestion would be to create a configuration option which gives control over precisely this behavior.  With a little guidance I could probably do it and resubmit, but I'm tossing this over the wall anyway right now so at least you know about what's involved.
