### PR TITLE
Make dates formattable

### DIFF
--- a/features/date_format.feature
+++ b/features/date_format.feature
@@ -1,0 +1,41 @@
+Feature: Date Formatting
+  As a content publisher
+  I want my dates to be formated correctly
+  so that I can ...
+
+  Scenario Outline: Date with configured date_format and correct dates
+    Given a config file with value:
+      """
+      { "date_format": "<date-format>" }
+      """
+      And some files with values:
+        | file              | date    | body            |
+        | _root/index.html  | <date>  | {{ page.date }} |
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And this file should contain the content "<formated-date>"
+    Examples:
+      | date        | date-format | formated-date     |
+      | 2013-12-11  | %Y.%m       | 2013.12           |
+      | 2012-01-1   |             |                   |
+      | 1991.11.11  | %B %d, %Y   | November 11, 1991 |
+      | 0-1-2       | %d/%m/%y    | 02/01/00          |
+
+
+  Scenario: Date without a configured date_format
+    Given some files with values:
+        | file              | date    | body            |
+        | _root/index.html  | 2013.12.11 | {{ page.date }} |
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And this file should contain the content "2013-12-11"
+
+  Scenario: Invalid date
+    Given some files with values:
+        | file              | date  | body            |
+        | _root/index.html  | 0-0   | {{ page.date }} |
+    When I try to compile my site
+    Then it should fail with:
+      """
+      ArgumentError: The date '0-0' specified in 'index.html' is unparsable.
+      """

--- a/features/step_defs.rb
+++ b/features/step_defs.rb
@@ -2,6 +2,10 @@ Transform(/^(should|should NOT)$/) do |matcher|
   matcher.downcase.gsub(' ', '_')
 end
 
+Given(/^a config file with value:$/) do |string|
+  make_config(JSON.parse(string))
+end
+
 Given(/^a config file with values:$/) do |table|
   data = table.rows_hash
   data.each{ |key, value| data[key] = JSON.parse(value) }
@@ -19,6 +23,27 @@ Given(/^some files with values:$/) do |table|
 
     make_file(path: file, data: row, body: body)
   end
+end
+
+When(/^I try to compile my site$/) do
+  begin
+    compile
+  rescue Exception => e
+    @exception = e
+  end
+end
+
+Then(/^it should fail$/) do
+  @exception.should_not be_nil
+end
+
+Then(/^it (should|should NOT) fail with:$/) do |matcher, content|
+  @exception.should_not be_nil
+  Ruhoh.log.buffer.last.__send__(matcher, have_content(content))
+end
+
+Then(/^the log (should|should NOT) include:$/) do |matcher, content|
+  Ruhoh.log.buffer.__send__(matcher, include(content))
 end
 
 When(/^I compile my site$/) do

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -2,6 +2,7 @@
 Encoding.default_internal = 'UTF-8'
 require 'json'
 require 'time'
+require 'ruhoh/time'
 require 'cgi'
 require 'fileutils'
 require 'ostruct'
@@ -80,6 +81,8 @@ class Ruhoh
     else
       config['base_path'] += "/" unless config['base_path'][-1] == '/'
     end
+
+    Time.default_format = config['date_format'] || "%Y-%m-%d"
 
     @config = config
   end

--- a/lib/ruhoh/base/model.rb
+++ b/lib/ruhoh/base/model.rb
@@ -73,7 +73,7 @@ module Ruhoh::Base
         data['date'] = Time.parse(data['date']) unless data['date'].nil? || data['date'].is_a?(Time)
       rescue
         Ruhoh.log.error(
-          "ArgumentError: The date '#{data['date']}' specified in '#{@pointer[id]}' is unparsable."
+          "ArgumentError: The date '#{data['date']}' specified in '#{@pointer['id']}' is unparsable."
         )
         data['date'] = nil
       end

--- a/lib/ruhoh/base/model.rb
+++ b/lib/ruhoh/base/model.rb
@@ -66,7 +66,17 @@ module Ruhoh::Base
       data['id'] = @pointer['id']
 
       data['title'] = data['title'] || filename_data['title']
-      data['date'] ||= filename_data['date'].to_s
+      data['date'] ||= filename_data['date']
+
+      # Parse and store date as an object
+      begin
+        data['date'] = Time.parse(data['date']) unless data['date'].nil? || data['date'].is_a?(Time)
+      rescue
+        Ruhoh.log.error(
+          "ArgumentError: The date '#{data['date']}' specified in '#{@pointer[id]}' is unparsable."
+        )
+        data['date'] = nil
+      end
       data['url'] = url(data)
       data['layout'] = collection.config['layout'] if data['layout'].nil?
 

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -44,10 +44,7 @@ module Ruhoh::Base
       this_data = __send__(attribute)
       other_data = other.__send__(attribute)
       if attribute == "date"
-        begin
-          this_data = Time.parse(this_data.to_s)
-          other_data = Time.parse(other_data.to_s)
-        rescue ArgumentError, TypeError
+        if this_data.nil? || other_data.nil?
           Ruhoh.log.error(
             "ArgumentError:" +
             " The '#{ @model.collection.resource_name }' collection is configured to sort based on 'date'" +

--- a/lib/ruhoh/resources/pages/collection_view.rb
+++ b/lib/ruhoh/resources/pages/collection_view.rb
@@ -41,11 +41,11 @@ module Ruhoh::Resources::Pages
       collated = []
       pages = all
       pages.each_with_index do |page, i|
-        thisYear = Time.parse(page['date'].to_s).strftime('%Y')
-        thisMonth = Time.parse(page['date'].to_s).strftime('%B')
+        thisYear = page['date'].strftime('%Y')
+        thisMonth = page['date'].strftime('%B')
         if (i-1 >= 0)
-          prevYear = Time.parse(pages[i-1]['date'].to_s).strftime('%Y')
-          prevMonth = Time.parse(pages[i-1]['date'].to_s).strftime('%B')
+          prevYear = pages[i-1]['date'].strftime('%Y')
+          prevMonth = pages[i-1]['date'].strftime('%B')
         end
 
         if(prevYear == thisYear) 

--- a/lib/ruhoh/time.rb
+++ b/lib/ruhoh/time.rb
@@ -1,0 +1,10 @@
+class Time
+  class << self
+    attr_accessor :default_format
+    default_format = "%Y-%m-%d %H:%M:%S %z"
+  end
+
+  def to_s
+    strftime Time.default_format
+  end
+end


### PR DESCRIPTION
This commit makes the date format customizable via the `date_format`
option. While this option is site-wide, specific dates can be formated
with `{{#date.strftime}}format_string{{/date.strftime}}`.

It does this by storing dates as Time objects and overriding `Time.to_s`.

Closes ruhoh/ruhoh.rb#69
