### PR TITLE
Cache the config file

### DIFF
--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -60,7 +60,9 @@ class Ruhoh
     @collections.load(resource)
   end
 
-  def config
+  def config(reload=false)
+    return @config unless (reload or @config.nil?)
+
     config = Ruhoh::Utils.parse_yaml_file(@base, "config.yml") || {}
     config['compiled'] = config['compiled'] ? File.expand_path(config['compiled']) : "compiled"
 

--- a/lib/ruhoh/programs/watch.rb
+++ b/lib/ruhoh/programs/watch.rb
@@ -27,15 +27,22 @@ class Ruhoh
             yellow "Watch [#{Time.now.strftime("%H:%M:%S")}] [Update #{path}] : #{args.size} files changed"
           }
 
-          separator = File::ALT_SEPARATOR ?
-                      %r{#{ File::SEPARATOR }|#{ File::ALT_SEPARATOR }} :
-                      File::SEPARATOR
-          resource = path.split(separator)[0]
+          if path == "config.yml"
+            ruhoh.config true
+          else
+            separator = File::ALT_SEPARATOR ?
+                        %r{#{ File::SEPARATOR }|#{ File::ALT_SEPARATOR }} :
+                        File::SEPARATOR
+            resource = path.split(separator)[0]
 
-          ruhoh.cache.delete(ruhoh.collection(resource).files_cache_key)
-          ruhoh.cache.delete("#{ resource }-all")
+            ruhoh.cache.delete(ruhoh.collection(resource).files_cache_key)
+            ruhoh.cache.delete("#{ resource }-all")
 
-          ruhoh.collection(resource).load_watcher.update(path)
+            puts("HERE", resource)
+
+            ruhoh.collection(resource).load_watcher.update(path)
+            puts(ruhoh.collection(resource))
+          end
         end
       end
 


### PR DESCRIPTION
This commit caches the config file the first time it is read. It also
adds a special case to the resource watcher to reload the config on
change. While a separate config resource could be added, this seems like
overkill.

This halves the compile time on my system and should help fix
ruhoh/ruhoh.rb#166.
