### PR TITLE
Support for user-defined sophisticated page creators via plugins 

### DIFF
--- a/lib/ruhoh/base/collection.rb
+++ b/lib/ruhoh/base/collection.rb
@@ -230,8 +230,8 @@ module Ruhoh::Base
       "#{ resource_name }-files"
     end
 
-    def scaffold
-      pointer = find_file('_scaffold', all: true) || @ruhoh.find_file('_scaffold')
+    def scaffold file = '_scaffold'
+      pointer = find_file(file, all: true) || @ruhoh.find_file(file)
       return '' unless pointer
 
       File.open(pointer['realpath'], 'r:UTF-8') { |f| f.read }

--- a/lib/ruhoh/base/collection.rb
+++ b/lib/ruhoh/base/collection.rb
@@ -117,7 +117,7 @@ module Ruhoh::Base
     # The file hashes are collected in order 
     # so they will overwrite eachother if found.
 
-    # @param id [String, Array] Optional.
+    # @param fid [String, Array] Optional.
     #   Collect all files for a single data resource.
     #   Can be many files due to the cascade.
     # @param [block] Optional.
@@ -126,7 +126,7 @@ module Ruhoh::Base
     #   Return true/false for whether the file is valid/invalid.
     #
     # @return[Hash] dictionary of pointers.
-    def files(id=nil, &block)
+    def files(fid=nil, &block)
       return @ruhoh.cache.get(files_cache_key) if @ruhoh.cache.get(files_cache_key)
 
       dict = _all_files

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -106,7 +106,7 @@ module Ruhoh::Base
 
       # Return a summary element if specified
       summary_el = content_doc.at_css('.summary')
-      return summary_el.to_html unless summary_el.nil?
+      return summary_el.to_html(:encoding => 'UTF-8') unless summary_el.nil?
 
       # Get the configuration parameters
       # Default to the parameters provided in the page itself
@@ -154,7 +154,7 @@ module Ruhoh::Base
         summary_doc << node
       end
 
-      summary_doc.to_html
+      summary_doc.to_html :encoding => 'UTF-8'
     end
 
     def next

--- a/lib/ruhoh/base/model_view.rb
+++ b/lib/ruhoh/base/model_view.rb
@@ -102,7 +102,7 @@ module Ruhoh::Base
     def summary
       # Parse the document
       full_content = @ruhoh.master_view(@model.pointer).render_content
-      content_doc = Nokogiri::HTML.fragment(full_content)
+      content_doc = Nokogiri::HTML.fragment(full_content, 'UTF-8')
 
       # Return a summary element if specified
       summary_el = content_doc.at_css('.summary')

--- a/lib/ruhoh/client.rb
+++ b/lib/ruhoh/client.rb
@@ -30,6 +30,7 @@ class Ruhoh
 
       @ruhoh.setup
       @ruhoh.setup_paths
+      @ruhoh.setup_plugins
 
       return __send__(cmd) if respond_to?(cmd)
 
@@ -66,11 +67,10 @@ class Ruhoh
       resources += @ruhoh.collections.all.map {|name|
         collection = @ruhoh.collection(name)
         next unless collection.client?
-        next unless collection.client.const_defined?(:Help)
-        {
-          "name" => name,
-          "methods" => collection.client.const_get(:Help)
+        helps = collection.client.constants.inject([]) {
+          |acc,c| acc += collection.client.const_get(c) if c.to_s.start_with?('Help')
         }
+        { "name" => name, "methods" => helps } unless helps.empty?
       }.compact
 
       Ruhoh::Friend.say { 

--- a/lib/ruhoh/converters/markdown.rb
+++ b/lib/ruhoh/converters/markdown.rb
@@ -8,9 +8,10 @@ class Ruhoh
       
       def self.convert(content)
         require 'redcarpet'
-        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:with_toc_data => true),
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:with_toc_data => true, :encoding => 'UTF-8'),
           :autolink => true, 
           :fenced_code_blocks => true, 
+          :encoding => 'UTF-8'
         )
         markdown.render(content)
       end

--- a/lib/ruhoh/converters/markdown.rb
+++ b/lib/ruhoh/converters/markdown.rb
@@ -1,3 +1,17 @@
+require "redcarpet"
+
+module Redcarpet
+  module RenderHTML5
+    # use html5-compliant figures instead of simple images
+    # ![Alt text](/path/to/img.jpg "Optional title")
+    class WithFigures < Redcarpet::Render::HTML
+      def image(link, title, alt)
+        "<figure><img src='#{link}' alt='#{alt}' /><figcaption><p>#{title}</p></figcaption></figure>"
+      end
+    end
+  end
+end
+
 class Ruhoh
   module Converter
     module Markdown
@@ -8,7 +22,7 @@ class Ruhoh
       
       def self.convert(content)
         require 'redcarpet'
-        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:with_toc_data => true, :encoding => 'UTF-8'),
+        markdown = Redcarpet::Markdown.new(Redcarpet::RenderHTML5::WithFigures.new(:with_toc_data => true, :encoding => 'UTF-8'),
           :autolink => true, 
           :fenced_code_blocks => true, 
           :encoding => 'UTF-8'

--- a/lib/ruhoh/resources/pages/client.rb
+++ b/lib/ruhoh/resources/pages/client.rb
@@ -89,7 +89,9 @@ module Ruhoh::Resources::Pages
       end while File.exist?(filename)
 
       FileUtils.mkdir_p File.dirname(filename)
-      output = (@collection.scaffold || '').gsub('{{DATE}}', Time.now.strftime('%Y-%m-%d'))
+      output = (@collection.scaffold || '').
+                gsub('{{DATE}}', Time.now.strftime('%Y-%m-%d')).
+                gsub('{{TITLE}}', file.gsub(/.*?\//, ''))
 
       File.open(filename, 'w:UTF-8') {|f| f.puts output }
 

--- a/lib/ruhoh/resources/pages/client.rb
+++ b/lib/ruhoh/resources/pages/client.rb
@@ -63,13 +63,11 @@ module Ruhoh::Resources::Pages
       _list(@collection.all)
     end
 
-    protected
+    private
 
-    def create(opts={})
-      ruhoh = @ruhoh
-
+    def filename_and_title(s=nil,opts={})
       begin
-        file = @args[2] || "untitled"
+        file = s || "untitled"
         ext = File.extname(file).to_s
         ext  = ext.empty? ? @collection.config["ext"] : ext
 
@@ -87,11 +85,19 @@ module Ruhoh::Resources::Pages
           File.join(@ruhoh.paths.base, @collection.resource_name, "#{name}#{ext}")
         @iterator += 1
       end while File.exist?(filename)
+      [filename, file.gsub(/.*?\//, '')]
+    end
+
+    protected
+
+    def create(opts={})
+      ruhoh = @ruhoh
+      filename, title = filename_and_title @args[2], opts
 
       FileUtils.mkdir_p File.dirname(filename)
       output = (@collection.scaffold || '').
                 gsub('{{DATE}}', Time.now.strftime('%Y-%m-%d')).
-                gsub('{{TITLE}}', file.gsub(/.*?\//, ''))
+                gsub('{{TITLE}}', title)
 
       File.open(filename, 'w:UTF-8') {|f| f.puts output }
 

--- a/lib/ruhoh/resources/pages/compiler.rb
+++ b/lib/ruhoh/resources/pages/compiler.rb
@@ -68,7 +68,7 @@ module Ruhoh::Resources::Pages
       Ruhoh::Friend.say { cyan "#{resource_name} RSS: (first #{limit} pages)" }
       data = @ruhoh.collection("data").dictionary
 
-      feed = Nokogiri::XML::Builder.new do |xml|
+      feed = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
        xml.rss(:version => '2.0') {
          xml.channel {
            xml.title_ data['title']

--- a/lib/ruhoh/views/helpers/paginator.rb
+++ b/lib/ruhoh/views/helpers/paginator.rb
@@ -13,6 +13,7 @@ module Ruhoh::Views::Helpers
       page_batch
     end
 
+    # [1][2] ... [n-1][n][n+1] ... [last-1][last]
     def paginator_navigation
       paginator_config = config["paginator"] || {}
       page_count = all.length
@@ -20,17 +21,42 @@ module Ruhoh::Views::Helpers
       current_page = master.page_data['current_page'].to_i
       current_page = current_page.zero? ? 1 : current_page
 
-      pages = total_pages.times.map { |i| 
+#      pages = total_pages.times.map { |i| 
+#        url = if i.zero? && paginator_config["root_page"]
+#                paginator_config["root_page"]
+#              else
+#                "#{paginator_config["url"]}/#{i+1}"
+#              end
+#
+#        {
+#          "url" => ruhoh.to_url(url),
+#          "name" => "#{i+1}",
+#          "is_active_page" => (i+1 == current_page)
+#        }
+#     }
+      left_dots = ((current_page+1)/2).ceil
+      right_dots = ((total_pages+current_page)/2).ceil
+      borders = paginator_config["borders"]
+
+      pages = total_pages.times.select { |i|
+        i+1 <= borders || i+1 > total_pages-borders || 
+        (i+1 >= current_page-(borders/2).ceil && i+1 <= current_page+(borders/2).ceil) || 
+        i+1 == left_dots || i+1 == right_dots                    
+      }.map { |i|
+        ii=i+1
         url = if i.zero? && paginator_config["root_page"]
                 paginator_config["root_page"]
               else
-                "#{paginator_config["url"]}/#{i+1}"
+                "#{paginator_config["url"]}/#{ii}"
               end
-
+        name = (i+1 > borders) && (i+1 < total_pages-borders) && 
+               ((i+1 < current_page-(borders/2).ceil) || (i+1 > current_page+(borders/2).ceil)) && 
+               (i+1 == left_dots || i+1 == right_dots) ? '…' : "#{i+1}"
         {
           "url" => ruhoh.to_url(url),
-          "name" => "#{i+1}",
-          "is_active_page" => (i+1 == current_page)
+          "name" => name,
+          "is_active_page" => (i+1 == current_page),
+          "title" => "#{i+1}"
         }
       }
       pages 

--- a/system/_image.html
+++ b/system/_image.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="{{IMGFILE}}" alt="{{IMGTITLE}}" />
+  <figcaption><p>{{IMGTITLE}}</figcaption>
+</figure>

--- a/system/_scaffold.html
+++ b/system/_scaffold.html
@@ -1,5 +1,5 @@
 ---
-title:
+title: '{{TITLE}}'
 date: '{{DATE}}'
 description:
 tags: []

--- a/system/widgets/analytics/yandex.html
+++ b/system/widgets/analytics/yandex.html
@@ -1,0 +1,31 @@
+---
+tracking_id : '21820303'
+---
+
+<!-- Yandex.Metrika counter -->
+<script type="text/javascript">
+(function (d, w, c) {
+    (w[c] = w[c] || []).push(function() {
+        try {
+            w.yaCounter21820303 = new Ya.Metrika({id:{{ this_config.tracking_id }},
+                    webvisor:true,
+                    clickmap:true,
+                    trackLinks:true,
+                    accurateTrackBounce:true});
+        } catch(e) { }
+    });
+
+    var n = d.getElementsByTagName("script")[0],
+        s = d.createElement("script"),
+        f = function () { n.parentNode.insertBefore(s, n); };
+    s.type = "text/javascript";
+    s.async = true;
+    s.src = (d.location.protocol == "https:" ? "https:" : "http:") + "//mc.yandex.ru/metrika/watch.js";
+
+    if (w.opera == "[object Opera]") {
+        d.addEventListener("DOMContentLoaded", f, false);
+    } else { f(); }
+})(document, window, "yandex_metrika_callbacks");
+</script>
+<noscript><div><img src="//mc.yandex.ru/watch/{{ this_config.tracking_id }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<!-- /Yandex.Metrika counter -->


### PR DESCRIPTION
Whilst the built-in page creator (called via `posts new`) is likely sufficient for standard blog entries, it could be a great helper for some special post types, like photo publishing. E. g. when I publish the photo to my blog, I really want to run smth like `posts new_image ~/Images/Vacation/123456.jpg 'Crocodile eats my leg'` and yield the scaffolded markdown with link to image, an alternate text etc. Plus I want the original file to be resized to, say, 500px wide, watermarked, blackjacked and whored (and put to /media folder within all the thumbnails).

Or I may want to run `posts publish_new` to minimize FTP/SCP traffic.

To accomplish the task I have an amount of plugins, extending base `ruhoh posts` functionality, written. Now the problem is that the infrastructure is not ready to load those plugins within ruhoh executable. The patch below is to support plugins, having monkeypatched `Ruhoh::Resources::Pages::Client` with `Help_WHATEVER` const defined as well as respective methods.
