### PR TITLE
Google Analytics support for _setDomainName

### DIFF
--- a/system/widgets/analytics/google.html
+++ b/system/widgets/analytics/google.html
@@ -7,6 +7,7 @@ tracking_id : 'UA-123-12'
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '{{ this_config.tracking_id }}']);
   _gaq.push(['_trackPageview']);
+  {{# this_config.domain_name }}_gaq.push(['_setDomainName', '{{ . }}']);{{/ this_config.domain_name }}
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
Many people setup their DNS settings in a way to treat domainname.com and www.domainname.com as equivalent. Google Analytics, by default, treats domainname.com and www.domainname.com as separate. To have GA track both top-level domain and sub-domains under the same report, _setDomainName() has to be used. 

More info here:
https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite#yourDomainName

This patch introduces a domain_name configuration for the Google Analytics widget. If set, _setDomainName() is called with the corresponding value.
