### PR TITLE
Expose production_url

### DIFF
--- a/lib/ruhoh/collections.rb
+++ b/lib/ruhoh/collections.rb
@@ -114,6 +114,7 @@ class Ruhoh
     def url_endpoints
       urls = {}
       urls["base_path"] = @ruhoh.base_path
+      urls["production_url"] = @ruhoh.config["production_url"]
 
       all.each do |name|
         collection = load(name)


### PR DESCRIPTION
For some reason, `{{ urls.production_url }}` no longer works. This might not be the correct fix but it works.
