### PR TITLE
Expose the total number of pages in a pagination.

### DIFF
--- a/lib/ruhoh/resources/pages/compiler.rb
+++ b/lib/ruhoh/resources/pages/compiler.rb
@@ -46,6 +46,7 @@ module Ruhoh::Resources::Pages
           view.page_data = {
             "layout" => config["layout"],
             "current_page" => (i+1),
+            "total_pages" => total_pages,
             "url" => @ruhoh.to_url(url)
           }
           FileUtils.mkdir_p File.dirname(view.compiled_path)


### PR DESCRIPTION
This makes it possible to access the total number of pages in a pagination through `page_data.total_pages`.
