### PR TITLE
Recursive layouts

### DIFF
--- a/features/layouts.feature
+++ b/features/layouts.feature
@@ -39,3 +39,18 @@ Feature: Layouts
     Then my compiled site should have the file "essays/hello/index.html"
       And this file should contain the content node "div#minimal-layout|cookie dough"
       And this file should contain the content node "div#minimal-sub-layout|cookie dough"
+
+  Scenario: Defining more than two layouts.
+    Given some files with values:
+      | file               | body                                                           | layout  |
+      | layouts/outer.md | <div id="minimal-outer-layout">outer {{{ content }}}</div>                 |         |
+      | layouts/inner.md   | <div id="minimal-inner-layout">inner {{{ content }}}</div>           | outer |
+      | layouts/essays.md  | <div id="minimal-layout">{{{ content }}}</div>             | inner   |
+      | essays/hello.md    | cookie dough                                                   | essays  |
+    When I compile my site
+    Then my compiled site should have the file "essays/hello/index.html"
+      And this file should contain the content node "div#minimal-outer-layout|inner"
+      And this file should contain the content node "div#minimal-inner-layout|cookie dough"
+      And this file should NOT contain the content node "div#minimal-inner-layout|outer"
+      And this file should NOT contain the content node "div#minimal-layout|outer"
+      And this file should NOT contain the content node "div#minimal-layout|inner"


### PR DESCRIPTION
This commit removes the two layout limit. Any number of non-repeating layouts may be used and will be rendered in order (top down).

Unlike the previous layout rendering code, this version does not double render the layouts. The previous version would render the sub-layout, then render the master layout embedding (without re-rendering) the sub-layout, and then re-render the combined layout with the page content (rendered separately).
