### PR TITLE
Support JSON data-type in config, data, and page metadata.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ gemspec
 
 gem 'rack', "~> 1.4"
 gem 'directory_watcher', "~> 1.4.0"
-gem 'psych', "~> 1.3", :platforms => [:ruby_18, :mingw_18]
 gem 'redcarpet', "~> 2.1"
 gem 'nokogiri', "~> 1.5"
 

--- a/features/data.feature
+++ b/features/data.feature
@@ -30,3 +30,34 @@ Feature: Data
       And this file should contain the content node "city|alhambra"
       And this file should contain the content node "li|mango"
       And this file should contain the content node "li|kiwi"
+
+  Scenario: Defining a basic data structure in data.json
+    Given the file "data.json" with body:
+      """
+      {
+        "address": {
+          "city": "alhambra"
+        }, 
+        "name": "jade", 
+        "fruits": [
+          "mango", 
+          "kiwi"
+        ]
+      }
+      """
+      And the file "_root/index.html" with body:
+        """
+        <name>{{ data.name }}</name>
+        <city>{{ data.address.city }}</city>
+        <ul>
+        {{# data.fruits }}
+          <li>{{ . }}</li>
+        {{/ data.fruits }}
+        </ul>
+        """
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And this file should contain the content node "name|jade"
+      And this file should contain the content node "city|alhambra"
+      And this file should contain the content node "li|mango"
+      And this file should contain the content node "li|kiwi"

--- a/features/json.feature
+++ b/features/json.feature
@@ -1,0 +1,33 @@
+Feature: Config
+  As a content publisher
+  I want the option to configure my site in JSON
+  because JSON is the preferred data format for modern web-technologies
+  and it benefits me to learn and get used to it, not to mention YAML is more
+  problematic than it's worth.
+
+  Scenario: Setting configuration in JSON
+    Given some files with values:
+      | file       | body |
+      | config.json | { "production_url" : "http://hello-world.com" } |
+      | _root/index.html | <span>{{ urls.production_url }}</span> |
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And this file should contain the content node "span|http://hello-world.com"
+
+  Scenario: Setting Top Metadata in JSON
+    Given the file "_root/index.html" with body:
+      """
+      {
+        "title" : "Hello World",
+        "author" : "Isosceles",
+        "tags" : ["apple", "orange"]
+      }
+
+      <title>{{ page.title }}</title>
+
+      <author>{{ page.author }}</author>
+      """
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And this file should contain the content node "title|Hello World"
+      And this file should contain the content node "author|Isosceles"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -40,11 +40,17 @@ def make_file(opts)
   metadata = data.empty? ? '' : data.to_yaml.to_s + "\n---\n"
 
   File.open(path, "w+") { |file|
-    file.puts <<-TEXT
+    if metadata.empty?
+      file.puts <<-TEXT
+#{ opts[:body] }
+TEXT
+    else
+      file.puts <<-TEXT
 #{ metadata }
 
 #{ opts[:body] }
 TEXT
+    end
   }
 end
 

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -1,8 +1,5 @@
 # encoding: UTF-8
 Encoding.default_internal = 'UTF-8'
-require 'yaml'
-require 'psych'
-YAML::ENGINE.yamler = 'psych'
 require 'json'
 require 'time'
 require 'cgi'
@@ -17,6 +14,7 @@ require 'mustache'
 require 'ruhoh/logger'
 require 'ruhoh/utils'
 require 'ruhoh/friend'
+require 'ruhoh/parse'
 
 require 'ruhoh/converter'
 require 'ruhoh/views/master_view'
@@ -65,7 +63,7 @@ class Ruhoh
   def config(reload=false)
     return @config unless (reload or @config.nil?)
 
-    config = Ruhoh::Utils.parse_yaml_file(@base, "config.yml") || {}
+    config = Ruhoh::Parse.data_file(@base, "config") || {}
     config['compiled'] = config['compiled'] ? File.expand_path(config['compiled']) : "compiled"
 
     config['_root'] ||= {}

--- a/lib/ruhoh/base/collection.rb
+++ b/lib/ruhoh/base/collection.rb
@@ -81,7 +81,7 @@ module Ruhoh::Base
     def config
       config = @ruhoh.config[resource_name] || {}
       unless config.is_a?(Hash)
-        Ruhoh.log.error("'#{resource_name}' config key in config.yml" +
+        Ruhoh.log.error("'#{resource_name}' config key in config" +
                         " is a #{config.class}; it needs to be a Hash (object).")
       end
       config
@@ -251,7 +251,7 @@ module Ruhoh::Base
         else
           klass = camelize(type)
           Friend.say {
-            red "#{resource_name} resource set to use:'#{type}' in config.yml" +
+            red "#{resource_name} resource set to use:'#{type}' in config" +
                 " but Ruhoh::Resources::#{klass} does not exist."
           }
           abort

--- a/lib/ruhoh/collections.rb
+++ b/lib/ruhoh/collections.rb
@@ -146,7 +146,7 @@ class Ruhoh
         else
           klass = camelize(type)
           Friend.say {
-            red "#{resource} resource set to use:'#{type}' in config.yml but Ruhoh::Resources::#{klass} does not exist."
+            red "#{resource} resource set to use:'#{type}' in config but Ruhoh::Resources::#{klass} does not exist."
           }
           abort
         end

--- a/lib/ruhoh/parse.rb
+++ b/lib/ruhoh/parse.rb
@@ -1,0 +1,89 @@
+class Ruhoh
+  module Parse
+    TopYAMLregex = /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
+    TopJSONregex = /^({\s*\n.*?\n?)^(}\s*$\n?)/m
+
+    # Primary method to parse the file as a page-like object.
+    # File API is currently defines:
+    #   1. Top meta-data
+    #   2. Page Body
+    #
+    # @returns[Hash Object] processed top meta-data, raw (unconverted) content body
+    def self.page_file(filepath)
+      result = {}
+      front_matter = nil
+      format = nil
+      page = File.open(filepath, 'r:UTF-8') { |f| f.read }
+      first_line = page.lines.first
+
+      begin
+        if (first_line.strip == '---')
+          front_matter = page.match(TopYAMLregex)
+          format = 'yaml'
+       elsif (first_line.strip == '{')
+          front_matter = page.match(TopJSONregex)
+          format = 'json'
+        end
+      rescue => e
+        raise "Error trying to read meta-data from #{ filepath }." +
+        " Check your folder configuration.  Error details: #{e}"
+      end
+
+      if format == 'yaml'
+        data = yaml_for_pages(front_matter, filepath)
+        result["content"] = page.gsub(TopYAMLregex, '')
+      else
+        data = json_for_pages(front_matter, filepath)
+        result["content"] = page.gsub(TopJSONregex, '')
+      end
+
+      result["data"] = data
+      result
+    end
+
+    def self.data_file(*args)
+      base = File.__send__(:join, args)
+
+      filepath = nil
+      ["#{ base }.json", "#{ base }.yml", "#{ base }.yaml"].each do |result|
+        filepath = result and break if File.exist?(result)
+      end
+      return nil unless filepath
+
+      file = File.open(filepath, 'r:UTF-8') { |f| f.read }
+
+      File.extname(filepath) == ".json" ? json(file) : yaml(file)
+    end
+
+    def self.yaml(file)
+      puts "YAML parser"
+      YAML.load(file) || {}
+    rescue Psych::SyntaxError => e
+      Ruhoh.log.error("ERROR in #{filepath}: #{e.message}")
+      nil
+    end
+
+    def self.json(file)
+      puts "JSON parser"
+      JSON.load(file) || {}
+    end
+
+    def self.yaml_for_pages(front_matter, filepath)
+      puts "YAML frontmatter"
+      return {} unless front_matter
+      YAML.load(front_matter[0].gsub(/---\n/, "")) || {}
+    rescue Psych::SyntaxError => e
+      Ruhoh.log.error("Psych::SyntaxError while parsing top YAML Metadata in #{ filepath }\n" +
+        "#{ e.message }\n" +
+        "Try validating the YAML metadata using http://yamllint.com"
+      )
+      nil
+    end
+
+    def self.json_for_pages(front_matter, filepath)
+      puts "JSON frontmatter"
+      return {} unless front_matter
+      JSON.load(front_matter[0]) || {}
+    end
+  end
+end

--- a/lib/ruhoh/programs/watch.rb
+++ b/lib/ruhoh/programs/watch.rb
@@ -27,7 +27,7 @@ class Ruhoh
             yellow "Watch [#{Time.now.strftime("%H:%M:%S")}] [Update #{path}] : #{args.size} files changed"
           }
 
-          if path == "config.yml"
+          if %w{ config.json config.yml config.yaml }.include?(path)
             ruhoh.config true
           else
             separator = File::ALT_SEPARATOR ?

--- a/lib/ruhoh/resources/data/collection.rb
+++ b/lib/ruhoh/resources/data/collection.rb
@@ -3,7 +3,7 @@ module Ruhoh::Resources::Data
     include Ruhoh::Base::Collectable
 
     def dictionary
-      Ruhoh::Utils.parse_yaml_file(@ruhoh.paths.base, "#{resource_name}.yml") || {}
+      Ruhoh::Parse.data_file(@ruhoh.paths.base, resource_name) || {}
     end
   end
 end

--- a/lib/ruhoh/resources/theme/compiler.rb
+++ b/lib/ruhoh/resources/theme/compiler.rb
@@ -39,7 +39,7 @@ module Ruhoh::Resources::Theme
       }
     end
 
-    # Checks a given asset filepath against any user-defined exclusion rules in theme.yml
+    # Checks a given asset filepath against any user-defined exclusion rules in config
     # Omit layouts, stylesheets, javascripts, media as they are handled by their respective resources.
     # @returns[Boolean]
     def is_valid_asset?(filepath)

--- a/lib/ruhoh/resources/widgets/collection_view.rb
+++ b/lib/ruhoh/resources/widgets/collection_view.rb
@@ -9,7 +9,7 @@ module Ruhoh::Resources::Widgets
       model = find("#{ name }/#{ (widget_config['use'] || "default") }")
       return '' unless model
 
-      # merge the config.yml data into the inline layout data.
+      # merge the config data into the inline layout data.
       # Note this is reversing the normal hierarchy 
       # in that inline should always override config level.
       # However the inline in this case is set as implementation defaults 

--- a/lib/ruhoh/utils.rb
+++ b/lib/ruhoh/utils.rb
@@ -1,20 +1,6 @@
 class Ruhoh
   module Utils
-    
-    FMregex = /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
-    
-    def self.parse_yaml_file(*args)
-      filepath = File.__send__ :join, args
-      return nil unless File.exist? filepath
 
-      file = File.open(filepath, 'r:UTF-8') {|f| f.read }
-      yaml = YAML.load(file) || {}
-      yaml
-    rescue Psych::SyntaxError => e
-      Ruhoh.log.error("ERROR in #{filepath}: #{e.message}")
-      nil
-    end
-    
     def self.url_to_path(url, base=nil)
       url = url.gsub(/^\//, '')
       parts = url.split('/')


### PR DESCRIPTION
Drop dependency on YAML and YAML gem since it causes lots of installation problems.
YAML should still be supported by ruby's native yaml lib as of 1.9+
