### PR TITLE
Add option to specify host in builtin web-server

### DIFF
--- a/lib/ruhoh/client.rb
+++ b/lib/ruhoh/client.rb
@@ -120,7 +120,8 @@ class Ruhoh
       require 'rack'
       Rack::Server.start({ 
         app: Ruhoh::Program.preview,
-        Port: (@args[1] || 9292)
+        Port: (@args[1] || 9292),
+        Host: (@args[2] || "0.0.0.0")
       })
     end
     alias_method :s, :server


### PR DESCRIPTION
I've added an option to specify the host when using the builtin web-server. This is useful for services like cloud9 where the default host ip is not accessible.
