### PR TITLE
Allow Ruhoh to load plugins using bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ end
 group :test do
   gem 'cucumber'
   gem 'capybara'
-  gem "rspec-expectations"
+  gem 'rspec'
 end

--- a/bin/ruhoh
+++ b/bin/ruhoh
@@ -2,8 +2,12 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'bundler'
-Bundler.require :default
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+if File.exists?(ENV['BUNDLE_GEMFILE'])
+  require 'bundler/setup'
+  Bundler.require :default
+end
 
 require 'ruhoh'
 require 'ruhoh/version'

--- a/bin/ruhoh
+++ b/bin/ruhoh
@@ -2,6 +2,9 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
+require 'bundler'
+Bundler.require :default
+
 require 'ruhoh'
 require 'ruhoh/version'
 require 'ruhoh/client'
@@ -13,7 +16,7 @@ options = Options.new
 
 opt_parser = OptionParser.new do |opts|
   opts.banner = 'Use `ruhoh help` for full command list.'
-  
+
   opts.on("--hg", "Use mercurial (hg) instead of git for source control.") do
     options.hg = true
   end
@@ -21,13 +24,13 @@ opt_parser = OptionParser.new do |opts|
   opts.on("-v", "--[no-]verbose", "Run verbosely. For pages, shows extra title, url meta-data.") do |v|
     options.verbose = v
   end
-    
+
   opts.on("--version", "Display current gem and ruhoh specification versions.") do
     puts "ruhoh " + Ruhoh::VERSION
     puts "RuhohSpec " + Ruhoh::RuhohSpec
     exit 0
   end
-  
+
 end
 opt_parser.parse!
 

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -26,6 +26,7 @@ require 'ruhoh/routes'
 require 'ruhoh/string_format'
 require 'ruhoh/url_slug'
 require 'ruhoh/programs/preview'
+require 'ruhoh/plugins/plugin'
 
 class Ruhoh
   class << self
@@ -135,6 +136,8 @@ class Ruhoh
 
     plugins = Dir[File.join(@base, "plugins", "**/*.rb")]
     plugins.each {|f| require f } unless plugins.empty?
+
+    Ruhoh::Plugins::Plugin.run_all self
   end
 
   def env

--- a/lib/ruhoh.rb
+++ b/lib/ruhoh.rb
@@ -133,9 +133,7 @@ class Ruhoh
       sprockets = Dir[File.join(@paths.system, "plugins", "sprockets", "**/*.rb")]
       sprockets.each {|f| require f }
     end
-
-    plugins = Dir[File.join(@base, "plugins", "**/*.rb")]
-    plugins.each {|f| require f } unless plugins.empty?
+    require 'ruhoh/plugins/local_plugins_plugin'
 
     Ruhoh::Plugins::Plugin.run_all self
   end

--- a/lib/ruhoh/plugins/initializer.rb
+++ b/lib/ruhoh/plugins/initializer.rb
@@ -1,0 +1,24 @@
+module Ruhoh::Plugins
+  class Initializer
+    attr_reader :name
+
+    def initialize name, &block
+      raise ArgumentError, "block required for initializer '#{name}'" unless block_given?
+      @name, @block = name, block
+    end
+
+    def run *args
+      raise "Initializer '#{name}' need to be bound" unless context
+      context.instance_exec *args, &block
+    end
+
+    def bind ctx
+      @context = ctx
+      self
+    end
+
+    private
+
+    attr_reader :block, :context
+  end
+end

--- a/lib/ruhoh/plugins/local_plugins_plugin.rb
+++ b/lib/ruhoh/plugins/local_plugins_plugin.rb
@@ -1,0 +1,10 @@
+module Ruhoh::Plugins
+  class LocalPluginsPlugin
+    include Plugin
+
+    initializer 'ruhoh.local_plugins' do
+      plugins = Dir[File.join(@base, "plugins", "**/*.rb")]
+      plugins.each { |f| require f }
+    end
+  end
+end

--- a/lib/ruhoh/plugins/plugin.rb
+++ b/lib/ruhoh/plugins/plugin.rb
@@ -1,0 +1,27 @@
+require 'ruhoh/plugins/initializer'
+
+module Ruhoh::Plugins
+  module Plugin
+    def self.included base
+      base.send :extend, ClassMethods
+    end
+
+    def self.run_all(context, *args)
+      initializers.each do |i|
+        i.bind(context).run *args
+      end
+    end
+
+    protected
+
+    def self.initializers
+      @initializers ||= []
+    end
+
+    module ClassMethods
+      def initializer name, &block
+        Plugin.initializers << Initializer.new(name, &block)
+      end
+    end
+  end
+end

--- a/spec/lib/ruhoh/plugins/initializer_spec.rb
+++ b/spec/lib/ruhoh/plugins/initializer_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+module Ruhoh::Plugins
+  describe Initializer do
+    describe 'constructor' do
+      it 'raises an error when block is not defined' do
+        expect { Initializer.new 'foo' }.to raise_error ArgumentError
+        expect { Initializer.new('foo') { } }.to_not raise_error
+      end
+    end
+
+    describe '#run' do
+      it "raises an error when it's not bound" do
+        initializer = Initializer.new('foo') { }
+        expect { initializer.run }.to raise_error RuntimeError
+        expect { initializer.bind(self).run }.to_not raise_error
+      end
+
+      it 'executes the block in the bound context' do
+        initializer = Initializer.new('foo') do
+          self << 'a' if length == 1
+        end
+        obj = ['b']
+        expect { initializer.bind(obj).run }.to change(obj, :length).to 2
+      end
+
+      it 'passes given arguments to block' do
+        initializer = Initializer.new('foo') do |arg|
+          raise 'arg is absent' if arg != 'a'
+        end
+        expect { initializer.bind(self).run }.to raise_error 'arg is absent'
+        expect { initializer.run 'a' }.to_not raise_error
+      end
+    end
+
+    describe '#bind' do
+      it 'returns self' do
+        initializer = Initializer.new('foo') { }
+        initializer.bind(self).should == initializer
+      end
+    end
+  end
+end

--- a/spec/lib/ruhoh/plugins/plugin_spec.rb
+++ b/spec/lib/ruhoh/plugins/plugin_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Ruhoh::Plugins
+  describe Plugin do
+    describe '::initializers' do
+      it 'returns an array' do
+        Plugin.initializers.should be_a Array
+      end
+
+      it 'memoizes the array' do
+        Plugin.initializers.object_id.should == Plugin.initializers.object_id
+      end
+    end
+
+    context 'when included in a class' do
+      let(:instance_class) do
+        Class.new do
+          include Plugin
+        end
+      end
+
+      it 'defines the ::initializer method' do
+        instance_class.should respond_to :initializer
+      end
+
+      describe '::initializer' do
+        it 'appends to initializers collection' do
+          expect {
+            instance_class.initializer('foo') { }
+          }.to change(Plugin.initializers, :length).to 1
+        end
+
+        it 'appends an initializer object filled with given params' do
+          instance_class.initializer('foo') { }
+          Plugin.initializers.first.name.should == 'foo'
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require File.expand_path '../../lib/ruhoh', __FILE__


### PR DESCRIPTION
Hi,
to allow ruhoh to load plugins from gems I:
- required bundler in the ruhoh executable (only if gemfile is present)
- created a Plugin module that each plugin can include to use the "initializer" helper
- changed ruhoh.rb to execute all registered plugins

Each plugin is executed passing the Ruhoh instance as context.
I also moved the code that was loading the local plugins files in a plugin (LocalPluginsPlugin), I thought it could be a perfect example.

I added rspec to do some unit tests.
