### PR TITLE
Compress sprockets compiled sass/scss by default

### DIFF
--- a/system/plugins/sprockets/compiler.rb
+++ b/system/plugins/sprockets/compiler.rb
@@ -5,6 +5,7 @@ module Ruhoh::SprocketsPlugin
     extend Ruhoh::Base::CompilableAsset
     def run
       env = Sprockets::Environment.new
+      env.css_compressor = :sass
       env.logger = Logger.new(STDOUT)
       env.logger.level = Logger::WARN
 


### PR DESCRIPTION
This is a trivial change and shouldn't break anything but I don't want to push it straight to master.
