### PR TITLE
Add support for to_javascripts url property

### DIFF
--- a/features/javascripts.feature
+++ b/features/javascripts.feature
@@ -40,3 +40,39 @@ Feature: Javascripts
     When I compile my site
     Then my compiled site should have the file "index.html"
       And this file should have the fingerprinted javascripts "base, app, custom"
+
+  Scenario: Using javascript objects to resolve url
+    Given some files with values:
+      | file | body |
+      | javascripts/base.js | var meep; |
+      | javascripts/app.js | console.log('haro world') |
+      | javascripts/custom.js | console.log('haro world') |
+      And the file "_root/index.html" with body:
+        """
+        ---
+        custom: base.js
+        ---
+        {{# page.custom?to_javascripts }}
+          <script type="text/javascript" src="{{url}}"></script>
+        {{/ page.custom?to_javascripts }}
+        """
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And the file should have the fingerprinted javascript "base"
+
+  Scenario: Using javascript object to resolve url and id
+    Given some files with values:
+      | file | body |
+      | javascripts/base.js | var meep; |
+      | javascripts/app.js | console.log('haro world') |
+      | javascripts/custom.js | console.log('haro world') |
+      And the file "_root/index.html" with body:
+        """
+        {{# javascripts.all }}
+          <script type="text/javascript" id="{{id}}" src="{{url}}"></script>
+        {{/ javascripts.all }}
+        """
+    When I compile my site
+    Then my compiled site should have the file "index.html"
+      And the file should have the fingerprinted javascript "app, base, custom"
+

--- a/features/javascripts.feature
+++ b/features/javascripts.feature
@@ -58,7 +58,7 @@ Feature: Javascripts
         """
     When I compile my site
     Then my compiled site should have the file "index.html"
-      And the file should have the fingerprinted javascript "base"
+      And this file should have the fingerprinted javascripts "base"
 
   Scenario: Using javascript object to resolve url and id
     Given some files with values:
@@ -74,5 +74,5 @@ Feature: Javascripts
         """
     When I compile my site
     Then my compiled site should have the file "index.html"
-      And the file should have the fingerprinted javascript "app, base, custom"
+      And this file should have the fingerprinted javascripts "app, base, custom"
 

--- a/lib/ruhoh/resources/javascripts/collection_view.rb
+++ b/lib/ruhoh/resources/javascripts/collection_view.rb
@@ -27,8 +27,6 @@ module Ruhoh::Resources::Javascripts
       }.join("\n")
     end
 
-    protected
-
     def make_url(name)
       return name if name =~ /^(http:|https:)?\/\//i
 

--- a/lib/ruhoh/resources/javascripts/collection_view.rb
+++ b/lib/ruhoh/resources/javascripts/collection_view.rb
@@ -27,6 +27,12 @@ module Ruhoh::Resources::Javascripts
       }.join("\n")
     end
 
+    def all()
+      files.values.map { |pointer|
+        load_model_view(pointer)
+      }
+    end
+
     def make_url(name)
       return name if name =~ /^(http:|https:)?\/\//i
 

--- a/lib/ruhoh/resources/javascripts/model_view.rb
+++ b/lib/ruhoh/resources/javascripts/model_view.rb
@@ -1,7 +1,15 @@
 module Ruhoh::Resources::Javascripts
   class ModelView < SimpleDelegator
     def url()
-      self.collection.make_url(self.pointer['id'])
+      	self.collection.make_url(self.pointer['id'])
+    end
+
+    def id()
+    	self.pointer['id']
+    end
+
+    def path()
+    	self.pointer['realpath']
     end
   end
 end

--- a/lib/ruhoh/resources/javascripts/model_view.rb
+++ b/lib/ruhoh/resources/javascripts/model_view.rb
@@ -1,0 +1,7 @@
+module Ruhoh::Resources::Javascripts
+  class ModelView < SimpleDelegator
+    def url()
+      self.collection.make_url(self.pointer['id'])
+    end
+  end
+end


### PR DESCRIPTION
1. Unprotect make_url.
2. Add simple delegator for model.url.

This will allow

``` mustache

---
custom: some.js

---
{{# page.custom?to_javascripts }}
   <script type="text/javascript" src="{{ url }}"></script>
{{/ page.custom?to_javascripts }}
```

to render out

``` html
<script type="text/javascript" src="/assets/javascripts/some-...hash....js"></script>
```

using the correct fingerprinted javascript file url.
