### PR TITLE
Add Google+ enabled comments.

### DIFF
--- a/system/widgets/comments/gplus.html
+++ b/system/widgets/comments/gplus.html
@@ -1,0 +1,10 @@
+---
+---
+
+<script src="https://apis.google.com/js/plusone.js"></script>
+<div class="g-comments"
+    data-href="{{ urls.production_url }}{{ page.url }}"
+    data-width="600"
+    data-first_party_property="BLOGGER"
+    data-view_type="FILTERED_POSTMOD">
+</div>


### PR DESCRIPTION
Based on:
http://dashburst.com/how-to-add-google-comments-to-any-webpage-or-blog-unofficially/

Prototype can be seen in action at http://dig.floatingsun.net/dagger-vs-guice/
