### PR TITLE
Add highlightjs widget.

### DIFF
--- a/system/widgets/highlight/highlightjs.html
+++ b/system/widgets/highlight/highlightjs.html
@@ -1,0 +1,6 @@
+---
+---
+
+<link href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/styles/solarized_dark.min.css" rel="stylesheet">
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/highlight.min.js"></script> 
+<script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
Uses the solarized theme by default. A future version could possibly
make it configurable. http://highlightjs.org/

This widget is under the 'highlight' namespace. I propose that
google_prettify and syntax/prettify should be consolidated under this
namespace.
