### PR TITLE
RSS feed converts relative urls to absolute urls

### DIFF
--- a/features/javascripts.feature
+++ b/features/javascripts.feature
@@ -4,11 +4,17 @@ Feature: Javascripts
   so I can make my content interactive
 
   Scenario: Defining javascripts
-    Given some files with values:
-      | file | body |
-      | javascripts/base.js | var meep; |
-      | javascripts/app.js | console.log('haro world') |
-      | javascripts/custom.js | console.log('haro world') |
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com"
+      }
+      """
+      And some files with values:
+        | file | body |
+        | javascripts/base.js | var meep; |
+        | javascripts/app.js | console.log('haro world') |
+        | javascripts/custom.js | console.log('haro world') |
       And the file "_root/index.html" with body:
         """
         {{# javascripts.load }}
@@ -22,8 +28,13 @@ Feature: Javascripts
       And this file should have the fingerprinted javascripts "base, app, custom"
 
   Scenario: Defining javascripts in a theme
-    Given a config file with values:
-      | sample_theme | { "use" : "theme" } |
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "sample_theme": { "use" : "theme" }
+      }
+      """
       And some files with values:
         | file | body |
         | javascripts/base.js | var meep; |

--- a/features/rss.feature
+++ b/features/rss.feature
@@ -1,0 +1,56 @@
+Feature: RSS
+  As a content publisher
+  I want to generate RSS feed for my posts
+  so that my blog subscribers can track my writings
+
+  Scenario: Generate RSS feed if enabled
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "posts" : { "rss" : { "enable" : true } }
+      }
+      """
+    And some files with values:
+      | file | body |
+      | posts/watermelon.html | I like to eat watermelon =) |
+      | posts/orange.html | I do not like to eat orange |
+    When I compile my site
+    Then my compiled site should have the file "posts/rss.xml"
+      And this file should contain the content "http://www.fakedomain.com"
+      And this file should contain the content "I like to eat watermelon =)"
+      And this file should contain the content "I do not like to eat orange"
+
+  Scenario: Do not generate RSS feed if not enabled
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "posts" : { "rss" : { "enable" : false } }
+      }
+      """
+    And some files with values:
+      | file | body |
+      | posts/watermelon.html | I like to eat watermelon =) |
+      | posts/orange.html | I do not like to eat orange |
+    When I compile my site
+    Then my compiled site should NOT have the file "posts/rss.xml"
+
+  Scenario: Generate RSS feed with all relative urls converted to absolute urls to support various feed readers including feedburner and emailed posts
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "posts" : { "rss" : { "enable" : true } }
+      }
+      """
+    And some files with values:
+      | file | body |
+      | posts/watermelon.html | I like to eat <a href="articles/fruits/fav.html">watermelon</a> =)|
+      | posts/orange.html | I do not like to eat <a href="http://www.othersite.com/fruits/orange.html">orange</a> |
+      | posts/apple.html | I like to eat <a href="articles/fruits/fav.html">apple</a> <img src="/images/smiley.html"><span> especially <a href="articles/fruits/red-apples.html">red ones</a></span> |
+    When I compile my site
+    Then my compiled site should have the file "posts/rss.xml"
+      And this file should contain the content "I like to eat <a href="http://www.fakedomain.com/articles/fruits/fav.html">watermelon</a> =)"
+      And this file should contain the content "I do not like to eat <a href="http://www.othersite.com/fruits/orange.html">orange</a>"
+      And this file should contain the content "I like to eat <a href="http://www.fakedomain.com/articles/fruits/fav.html">apple</a> <img src="http://www.fakedomain.com/images/smiley.html"><span> especially <a href="http://www.fakedomain.com/articles/fruits/red-apples.html">red ones</a></span>"

--- a/features/step_defs.rb
+++ b/features/step_defs.rb
@@ -2,6 +2,10 @@ Transform(/^(should|should NOT)$/) do |matcher|
   matcher.downcase.gsub(' ', '_')
 end
 
+Given(/^a config file with value:$/) do |string|
+  make_config(JSON.parse(string))
+end
+
 Given(/^a config file with values:$/) do |table|
   data = table.rows_hash
   data.each{ |key, value| data[key] = JSON.parse(value) }

--- a/features/stylesheets.feature
+++ b/features/stylesheets.feature
@@ -4,11 +4,17 @@ Feature: Stylesheets
   so I can make my content presentation pleasing to the eye and intuitive for my readers
 
   Scenario: Defining stylesheets
-    Given some files with values:
-      | file | body |
-      | stylesheets/base.css | body { color: black } |
-      | stylesheets/app.css | div { color: black } |
-      | stylesheets/custom.css | div { color: black } |
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com"
+      }
+      """
+      And some files with values:
+        | file | body |
+        | stylesheets/base.css | body { color: black } |
+        | stylesheets/app.css | div { color: black } |
+        | stylesheets/custom.css | div { color: black } |
       And the file "_root/index.html" with body:
         """
         {{# stylesheets.load }}
@@ -22,8 +28,13 @@ Feature: Stylesheets
       And this file should have the fingerprinted stylesheets "base, app, custom"
 
   Scenario: Defining stylesheets in a theme
-    Given a config file with values:
-      | sample_theme | { "use" : "theme" } |
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "sample_theme": { "use" : "theme" }
+      }
+      """
       And some files with values:
         | file | body |
         | stylesheets/base.css | blah {} |

--- a/features/widgets/google_prettify.feature
+++ b/features/widgets/google_prettify.feature
@@ -4,9 +4,15 @@ Feature: Google Prettify Widget
   so I can easily add customized functionality without polluting my content files
 
   Scenario: Rendering a custom defined widget
-    Given some files with values:
-      | file                       | body |
-      | _root/index.md            | {{{ widgets.google_prettify }}} |
+    Given a config file with value:
+      """
+      {
+        "production_url" : "http://www.fakedomain.com"
+      }
+      """
+      And some files with values:
+        | file                       | body |
+        | _root/index.md            | {{{ widgets.google_prettify }}} |
     When I compile my site
     Then my compiled site should have the file "index.html"
       And this file should have the content node "script[src='http://cdnjs.cloudflare.com/ajax/libs/prettify/188.0.0/prettify.js']|"

--- a/features/widgets/syntax.feature
+++ b/features/widgets/syntax.feature
@@ -4,32 +4,32 @@ Feature: Syntax widget
   so users can more easily understand code examples I publish
 
   Scenario: Using prettify syntax highlighter
-    Given the file "config.yml" with body:
+    Given a config file with value:
       """
-      widgets:
-        syntax:
-          use: "prettify"
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "widgets" : { "syntax" : { "use" : "prettify" } }
+      }
       """
-    Given some files with values:
-      | file                       | body |
-      | _root/index.md            | {{{ widgets.syntax }}} |
+      And some files with values:
+        | file                       | body |
+        | _root/index.md            | {{{ widgets.syntax }}} |
     When I compile my site
     Then my compiled site should have the file "index.html"
       And this file should have the content node "script[src='/assets/widgets/syntax/javascripts/prettify.js']|"
       And my compiled site should have the file "assets/widgets/syntax/javascripts/prettify.js"
 
   Scenario: Using prettify syntax highlighter with cdn enabled
-    Given the file "config.yml" with body:
+    Given a config file with value:
       """
-      widgets:
-        syntax:
-          use: "prettify"
-          cdn:
-            enable: true
+      {
+        "production_url" : "http://www.fakedomain.com",
+        "widgets" : { "syntax" : { "use" : "prettify", "cdn" : { "enable" : true } } }
+      }
       """
-    Given some files with values:
-      | file                       | body |
-      | _root/index.md            | {{{ widgets.syntax }}} |
+      And some files with values:
+        | file                       | body |
+        | _root/index.md            | {{{ widgets.syntax }}} |
     When I compile my site
     Then my compiled site should have the file "index.html"
       And this file should have the content node "script[src='http://cdnjs.cloudflare.com/ajax/libs/prettify/188.0.0/prettify.js']|"


### PR DESCRIPTION
A common guideline is to use absolute urls instead of relative urls for RSS feeds. This is because some feed readers such as feedburner do not resolve the relative urls to the feed source domain. Relative urls also become a problem when people receive feed updates via email.

This pull request converts relative urls to absolute urls when compiling the RSS xml.

Please note that the request is against this commit: 
891870692d137792cabd6450bd972684cc6b5d07
Google Analytics now optionally supports setting _setDomainName using domain_name config value

I could not successfully get my current blog to work against the latest master of ruhoh.rb
