### PR TITLE
update travis to do rspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
 script:
   - "bundle exec cucumber -r features"
-  - "bundle exec rspec"
+  - "bundle exec rspec --format documentation"
 notifications:
   recipients:
     - ben.biddington@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-script: "bundle exec cucumber -r features"
+script:
+  - "bundle exec cucumber -r features"
+  - "bundle exec rspec"
 notifications:
   recipients:
     - ben.biddington@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
 script:
   - "bundle exec cucumber -r features"
-  - "bundle exec rspec --format documentation"
+  - "bundle exec rspec --color --format documentation"
 notifications:
   recipients:
     - ben.biddington@gmail.com


### PR DESCRIPTION
updated to do both rspec and cucumber, as the current implementation of ruhoh uses two test suites

because if want to have both test suites, you should run both test suites

![all the things](http://tommcfarlin.com/wp-content/uploads/2013/08/all-the-things.jpg)
