### PR TITLE
Allow hypens to appear in folder names

### DIFF
--- a/lib/ruhoh/url_slug.rb
+++ b/lib/ruhoh/url_slug.rb
@@ -22,7 +22,7 @@ class Ruhoh
     def dynamic
       cache = data
       result = @format
-                .gsub(/:[^\/\.]+/) { |a| cache[$&.gsub(':', '')] }
+                .gsub(/:[^\/\.-]+/) { |a| cache[$&.gsub(':', '')] }
                 .gsub('//', '/')
                 .split('/')
 


### PR DESCRIPTION
Corrects (maybe not in the most elegant way) the problem described in https://github.com/ruhoh/ruhoh.rb/issues/283

I have only added hyphens to this fix, and it appears there may be room for a more general solution in which the config file can list 'protected' punctuation in folder names. 
