### PR TITLE
generate RSS using RFC-822 compliant dates

### DIFF
--- a/lib/ruhoh/resources/pages/compiler.rb
+++ b/lib/ruhoh/resources/pages/compiler.rb
@@ -71,13 +71,13 @@ module Ruhoh::Resources::Pages
            xml.title_ data['title']
            xml.description_ (data['description'] ? data['description'] : data['title'])
            xml.link_ production_url
-           xml.pubDate_ Time.now          
+           xml.pubDate_ Time.now.strftime '%a, %d %b %Y %H:%M:%S %z'
            pages.each do |page|
              view = @ruhoh.master_view(page.pointer)
              xml.item {
                xml.title_ page.title
                xml.link "#{production_url}#{page.url}"
-               xml.pubDate_ page.date if page.date
+               xml.pubDate_ page.date.strftime '%a, %d %b %Y %H:%M:%S %z' if page.date
                xml.description_ with_absolute_urls(page.try(:description) ? page.description : view.render_content)
              }
            end


### PR DESCRIPTION
The RSS spec requires feeds to specify dates using the RFC-822 spec. The user can specify their own time format for display in config.yml, but RSS date formats can't be custom without making the feed invalid.

W3C has a great validator: http://validator.w3.org/feed/

I found this because my own little RSS reader got upset trying to read a feed created from a Ruhoh blog. Most big readers have relaxed parsing, but as long as doing it right is easy, I think we should :smile: 

I installed ruhoh and threw together a basic site, confirmed the default behavior and checked against W3C for failure, made these changes, and validated my feed afterward, and it looks like the cucumber tests pass too. Please let me know if there's something else that would be good to have in this change!
