### PR TITLE
corrected <link> with ending tag for valid XHTML

### DIFF
--- a/lib/ruhoh/resources/stylesheets/collection_view.rb
+++ b/lib/ruhoh/resources/stylesheets/collection_view.rb
@@ -23,7 +23,7 @@ module Ruhoh::Resources::Stylesheets
     def load(sub_context)
       stylesheets = sub_context.split("\n").map{ |s| s.gsub(/\s/, '') }.delete_if(&:empty?)
       stylesheets.map { |name|
-        "<link href='#{make_url(name)}' type='text/css' rel='stylesheet' media='all'>"
+        "<link href='#{make_url(name)}' type='text/css' rel='stylesheet' media='all' />"
       }.join("\n")
     end
 


### PR DESCRIPTION
Accroding to ruhoh/ruhoh.rb#298 , Since current implementation gives XHTML validation error because of `<link>` tag without ending tag. That ending tag was added.
